### PR TITLE
linter: Turn off 'disallowMultipleVarDecl'.

### DIFF
--- a/javascript/linters/jscsrc
+++ b/javascript/linters/jscsrc
@@ -15,7 +15,7 @@
   },
   "requireParenthesesAroundIIFE": true,
   "requireDotNotation": true,
-  "disallowMultipleVarDecl": true,
+  "disallowMultipleVarDecl": false,
   "requireCurlyBraces": [
     "if",
     "else",


### PR DESCRIPTION
This jscs setting conflicts with our styleguide; we [prefer to use multiple var statements](https://github.com/madbook/styleguide/tree/master/javascript#variables).

:eyeglasses: @dwick @ajacksified