### PR TITLE
Fix spelling error in README.md

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -619,7 +619,7 @@
 
 ## Blocks
 
-  - Use bracess. Single-line functions are okay if short. Single-line conditionals are okay if short.
+  - Use braces. Single-line functions are okay if short. Single-line conditionals are okay if short.
 
     ```javascript
     // bad


### PR DESCRIPTION
Update removes an 's' character to correct 'bracess' to 'braces'.