### PR TITLE
Add ES6 and React JavaScript styleguides

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -5,14 +5,21 @@
 ## Table of Contents
 
   1. [Types](#types)
+  1. [References](#references)
   1. [Objects](#objects)
   1. [Arrays](#arrays)
+  1. [Destructuring](#destructuring)
   1. [Strings](#strings)
   1. [Functions](#functions)
+  1. [Arrow Functions](#arrow-functions)
+  1. [Constructors](#constructors)
+  1. [Methods](#methods)
+  1. [Modules](#modules)
+  1. [Iterators and Generators](#iterators-and-generators)
   1. [Properties](#properties)
   1. [Variables](#variables)
   1. [Hoisting](#hoisting)
-  1. [Conditional Expressions & Equality](#conditional-expressions--equality)
+  1. [Comparison Operators & Equality](#comparison-operators--equality)
   1. [Blocks](#blocks)
   1. [Comments](#comments)
   1. [Whitespace](#whitespace)
@@ -21,11 +28,10 @@
   1. [Type Casting & Coercion](#type-casting--coercion)
   1. [Naming Conventions](#naming-conventions)
   1. [Accessors](#accessors)
-  1. [Constructors](#constructors)
   1. [Events](#events)
-  1. [Modules](#modules)
   1. [jQuery](#jquery)
   1. [ECMAScript 5 Compatibility](#ecmascript-5-compatibility)
+  1. [ECMAScript 6 Styles](#ecmascript-6-styles)
   1. [Testing](#testing)
   1. [Performance](#performance)
   1. [Resources](#resources)
@@ -33,7 +39,7 @@
 
 ## Types
 
-  - **Primitives**: When you access a primitive type you work directly on its value
+  - [1.1](#1.1) <a name='1.1'></a> **Primitives**: When you access a primitive type you work directly on its value.
 
     + `string`
     + `number`
@@ -42,22 +48,22 @@
     + `undefined`
 
     ```javascript
-    var foo = 1;
-    var bar = foo;
+    const foo = 1;
+    let bar = foo;
 
     bar = 9;
 
     console.log(foo, bar); // => 1, 9
     ```
-  - **Complex**: When you access a complex type you work on a reference to its value
+  - [1.2](#1.2) <a name='1.2'></a> **Complex**: When you access a complex type you work on a reference to its value.
 
     + `object`
     + `array`
     + `function`
 
     ```javascript
-    var foo = [1, 2];
-    var bar = foo;
+    const foo = [1, 2];
+    const bar = foo;
 
     bar[0] = 9;
 
@@ -66,72 +72,261 @@
 
 **[⬆ back to top](#table-of-contents)**
 
+## References
+
+  - [2.1](#2.1) <a name='2.1'></a> Use `const` for all of your references; avoid using `var`.
+
+    > Why? This ensures that you can't reassign your references, which can lead to bugs and difficult to comprehend code.
+
+    eslint rules: [`prefer-const`](http://eslint.org/docs/rules/prefer-const.html), [`no-const-assign`](http://eslint.org/docs/rules/no-const-assign.html).
+
+    ```javascript
+    // bad
+    var a = 1;
+    var b = 2;
+
+    // good
+    const a = 1;
+    const b = 2;
+    ```
+
+  - [2.2](#2.2) <a name='2.2'></a> If you must reassign references, use `let` instead of `var`.
+
+    > Why? `let` is block-scoped rather than function-scoped like `var`.
+
+    eslint rules: [`no-var`](http://eslint.org/docs/rules/no-var.html).
+
+    ```javascript
+    // bad
+    var count = 1;
+    if (true) {
+      count += 1;
+    }
+
+    // good, use the let.
+    let count = 1;
+    if (true) {
+      count += 1;
+    }
+    ```
+
+  - [2.3](#2.3) <a name='2.3'></a> Note that both `let` and `const` are block-scoped.
+
+    ```javascript
+    // const and let only exist in the blocks they are defined in.
+    {
+      let a = 1;
+      const b = 1;
+    }
+    console.log(a); // ReferenceError
+    console.log(b); // ReferenceError
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
 ## Objects
 
-  - Use the literal syntax for object creation.
+  - [3.1](#3.1) <a name='3.1'></a> Use the literal syntax for object creation.
+
+    eslint rules: [`no-new-object`](http://eslint.org/docs/rules/no-new-object.html).
 
     ```javascript
     // bad
-    var item = new Object();
+    const item = new Object();
 
     // good
-    var item = {};
+    const item = {};
     ```
 
-  - Don't use [reserved words](http://es5.github.io/#x7.6.1) as keys. It won't work in IE8. [More info](https://github.com/airbnb/javascript/issues/61)
+  - [3.2](#3.2) <a name='3.2'></a> If your code will be executed in browsers in script context, don't use [reserved words](http://es5.github.io/#x7.6.1) as keys. It won't work in IE8. [More info](https://github.com/airbnb/javascript/issues/61). It’s OK to use them in ES6 modules and server-side code.
 
     ```javascript
     // bad
-    var superman = {
+    const superman = {
       default: { clark: 'kent' },
-      private: true
+      private: true,
     };
 
     // good
-    var superman = {
+    const superman = {
       defaults: { clark: 'kent' },
-      hidden: true
+      hidden: true,
     };
     ```
 
-  - Use readable synonyms in place of reserved words.
+  - [3.3](#3.3) <a name='3.3'></a> Use readable synonyms in place of reserved words.
 
     ```javascript
     // bad
-    var superman = {
-      class: 'alien'
+    const superman = {
+      class: 'alien',
     };
 
     // bad
-    var superman = {
-      klass: 'alien'
+    const superman = {
+      klass: 'alien',
     };
 
     // good
-    var superman = {
-      type: 'alien'
+    const superman = {
+      type: 'alien',
     };
     ```
+
+  <a name="es6-computed-properties"></a>
+  - [3.4](#3.4) <a name='3.4'></a> Use computed property names when creating objects with dynamic property names.
+
+    > Why? They allow you to define all the properties of an object in one place.
+
+    ```javascript
+
+    function getKey(k) {
+      return `a key named ${k}`;
+    }
+
+    // bad
+    const obj = {
+      id: 5,
+      name: 'San Francisco',
+    };
+    obj[getKey('enabled')] = true;
+
+    // good
+    const obj = {
+      id: 5,
+      name: 'San Francisco',
+      [getKey('enabled')]: true,
+    };
+    ```
+
+  <a name="es6-object-shorthand"></a>
+  - [3.5](#3.5) <a name='3.5'></a> Use object method shorthand.
+
+    eslint rules: [`object-shorthand`](http://eslint.org/docs/rules/object-shorthand.html).
+
+    ```javascript
+    // bad
+    const atom = {
+      value: 1,
+
+      addValue: function (value) {
+        return atom.value + value;
+      },
+    };
+
+    // good
+    const atom = {
+      value: 1,
+
+      addValue(value) {
+        return atom.value + value;
+      },
+    };
+    ```
+
+  <a name="es6-object-concise"></a>
+  - [3.6](#3.6) <a name='3.6'></a> Use property value shorthand.
+
+    > Why? It is shorter to write and descriptive.
+
+    eslint rules: [`object-shorthand`](http://eslint.org/docs/rules/object-shorthand.html).
+
+    ```javascript
+    const lukeSkywalker = 'Luke Skywalker';
+
+    // bad
+    const obj = {
+      lukeSkywalker: lukeSkywalker,
+    };
+
+    // good
+    const obj = {
+      lukeSkywalker,
+    };
+    ```
+
+  - [3.7](#3.7) <a name='3.7'></a> Group your shorthand properties at the beginning of your object declaration.
+
+    > Why? It's easier to tell which properties are using the shorthand.
+
+    ```javascript
+    const anakinSkywalker = 'Anakin Skywalker';
+    const lukeSkywalker = 'Luke Skywalker';
+
+    // bad
+    const obj = {
+      episodeOne: 1,
+      twoJediWalkIntoACantina: 2,
+      lukeSkywalker,
+      episodeThree: 3,
+      mayTheFourth: 4,
+      anakinSkywalker,
+    };
+
+    // good
+    const obj = {
+      lukeSkywalker,
+      anakinSkywalker,
+      episodeOne: 1,
+      twoJediWalkIntoACantina: 2,
+      episodeThree: 3,
+      mayTheFourth: 4,
+    };
+    ```
+
+  - [3.8](#3.8) <a name="3.8"></a> Only quote properties that are invalid identifiers.
+
+  > Why? In general we consider it subjectively easier to read. It improves syntax highlighting, and is also more easily optimized by many JS engines.
+
+  eslint rules: [`quote-props`](http://eslint.org/docs/rules/quote-props.html).
+
+  ```javascript
+  // bad
+  const bad = {
+    'foo': 3,
+    'bar': 4,
+    'data-blah': 5,
+  };
+
+  // good
+  const good = {
+    foo: 3,
+    bar: 4,
+    'data-blah': 5,
+  };
+  ```
+
+  - [3.9](#3.9) <a name="3.9"></a> Use splats for copying objects.
+
+  ```javascript 
+  // not preferred
+  const newObj = Object.assign({}, oldObj);
+
+  // preferred
+  const newObj = {...oldObj};
+
+  ```
 
 **[⬆ back to top](#table-of-contents)**
 
 ## Arrays
 
-  - Use the literal syntax for array creation
+  - [4.1](#4.1) <a name='4.1'></a> Use the literal syntax for array creation.
+
+    eslint rules: [`no-array-constructor`](http://eslint.org/docs/rules/no-array-constructor.html).
 
     ```javascript
     // bad
-    var items = new Array();
+    const items = new Array();
 
     // good
-    var items = [];
+    const items = [];
     ```
 
-  - If you don't know array length use Array#push.
+  - [4.2](#4.2) <a name='4.2'></a> Use Array#push instead of direct assignment to add items to an array.
 
     ```javascript
-    var someStack = [];
-
+    const someStack = [];
 
     // bad
     someStack[someStack.length] = 'abracadabra';
@@ -140,141 +335,187 @@
     someStack.push('abracadabra');
     ```
 
-  - When you need to copy an array use Array#slice. [jsPerf](http://jsperf.com/converting-arguments-to-an-array/7)
+  <a name="es6-array-spreads"></a>
+  - [4.3](#4.3) <a name='4.3'></a> Use array spreads `...` to copy arrays.
 
     ```javascript
-    var len = items.length;
-    var itemsCopy = [];
-    var i;
-
     // bad
+    const len = items.length;
+    const itemsCopy = [];
+    let i;
+
     for (i = 0; i < len; i++) {
       itemsCopy[i] = items[i];
     }
 
     // good
-    itemsCopy = items.slice();
+    const itemsCopy = [...items];
     ```
-
-  - To convert an array-like object to an array, use Array#slice.
+  - [4.4](#4.4) <a name='4.4'></a> To convert an array-like object to an array, use Array#from.
 
     ```javascript
-    function trigger() {
-      var args = Array.prototype.slice.call(arguments);
-      ...
-    }
+    const foo = document.querySelectorAll('.foo');
+    const nodes = Array.from(foo);
     ```
 
 **[⬆ back to top](#table-of-contents)**
 
+## Destructuring
+
+  - [5.1](#5.1) <a name='5.1'></a> Use object destructuring when accessing and using multiple properties of an object.
+
+    > Why? Destructuring saves you from creating temporary references for those properties.
+
+    ```javascript
+    // bad
+    function getFullName(user) {
+      const firstName = user.firstName;
+      const lastName = user.lastName;
+
+      return `${firstName} ${lastName}`;
+    }
+
+    // good
+    function getFullName(user) {
+      const { firstName, lastName } = user;
+      return `${firstName} ${lastName}`;
+    }
+
+    // best
+    function getFullName({ firstName, lastName }) {
+      return `${firstName} ${lastName}`;
+    }
+    ```
+
+  - [5.2](#5.2) <a name='5.2'></a> Use array destructuring.
+
+    ```javascript
+    const arr = [1, 2, 3, 4];
+
+    // bad
+    const first = arr[0];
+    const second = arr[1];
+
+    // good
+    const [first, second] = arr;
+    ```
+
+  - [5.3](#5.3) <a name='5.3'></a> Use object destructuring for multiple return values, not array destructuring.
+
+    > Why? You can add new properties over time or change the order of things without breaking call sites.
+
+    ```javascript
+    // bad
+    function processInput(input) {
+      // then a miracle occurs
+      return [left, right, top, bottom];
+    }
+
+    // the caller needs to think about the order of return data
+    const [left, __, top] = processInput(input);
+
+    // good
+    function processInput(input) {
+      // then a miracle occurs
+      return { left, right, top, bottom };
+    }
+
+    // the caller selects only the data they need
+    const { left, right } = processInput(input);
+    ```
+
+
+**[⬆ back to top](#table-of-contents)**
 
 ## Strings
 
-  - Use single quotes `''` for strings
+  - [6.1](#6.1) <a name='6.1'></a> Use single quotes `''` for strings.
+
+    eslint rules: [`quotes`](http://eslint.org/docs/rules/quotes.html).
 
     ```javascript
     // bad
-    var name = "Bob Parr";
+    const name = "Capt. Janeway";
 
     // good
-    var name = 'Bob Parr';
-
-    // bad
-    var fullName = "Bob " + this.lastName;
-
-    // good
-    var fullName = 'Bob ' + this.lastName;
+    const name = 'Capt. Janeway';
     ```
 
-  - Strings longer than 80 characters should be written across multiple lines using string concatenation.
-  - Note: If overused, long strings with concatenation could impact performance. [jsPerf](http://jsperf.com/ya-string-concat) & [Discussion](https://github.com/airbnb/javascript/issues/40)
+  - [6.2](#6.2) <a name='6.2'></a> Strings that cause the line to go over 100 characters should be written across multiple lines using string concatenation.
+  - [6.3](#6.3) <a name='6.3'></a> Note: If overused, long strings with concatenation could impact performance. [jsPerf](http://jsperf.com/ya-string-concat) & [Discussion](https://github.com/airbnb/javascript/issues/40).
 
     ```javascript
     // bad
-    var errorMessage = 'This is a super long error that was thrown because of Batman. When you stop to think about how Batman had anything to do with this, you would get nowhere fast.';
+    const errorMessage = 'This is a super long error that was thrown because of Batman. When you stop to think about how Batman had anything to do with this, you would get nowhere fast.';
 
     // bad
-    var errorMessage = 'This is a super long error that was thrown because \
+    const errorMessage = 'This is a super long error that was thrown because \
     of Batman. When you stop to think about how Batman had anything to do \
     with this, you would get nowhere \
     fast.';
 
     // good
-    var errorMessage = 'This is a super long error that was thrown because ' +
+    const errorMessage = 'This is a super long error that was thrown because ' +
       'of Batman. When you stop to think about how Batman had anything to do ' +
       'with this, you would get nowhere fast.';
     ```
 
-  - When programmatically building up a string, use Array#join instead of string concatenation. Mostly for IE: [jsPerf](http://jsperf.com/string-vs-array-concat/2).
+  <a name="es6-template-literals"></a>
+  - [6.4](#6.4) <a name='6.4'></a> When programmatically building up strings, use template strings instead of concatenation.
+
+    > Why? Template strings give you a readable, concise syntax with proper newlines and string interpolation features.
+
+    eslint rules: [`prefer-template`](http://eslint.org/docs/rules/prefer-template.html).
 
     ```javascript
-    var items;
-    var messages;
-    var length;
-    var i;
-
-    messages = [{
-      state: 'success',
-      message: 'This one worked.'
-    }, {
-      state: 'success',
-      message: 'This one worked as well.'
-    }, {
-      state: 'error',
-      message: 'This one did not work.'
-    }];
-
-    length = messages.length;
+    // bad
+    function sayHi(name) {
+      return 'How are you, ' + name + '?';
+    }
 
     // bad
-    function inbox(messages) {
-      items = '<ul>';
-
-      for (i = 0; i < length; i++) {
-        items += '<li>' + messages[i].message + '</li>';
-      }
-
-      return items + '</ul>';
+    function sayHi(name) {
+      return ['How are you, ', name, '?'].join();
     }
 
     // good
-    function inbox(messages) {
-      items = [];
-
-      for (i = 0; i < length; i++) {
-        items[i] = messages[i].message;
-      }
-
-      return '<ul><li>' + items.join('</li><li>') + '</li></ul>';
+    function sayHi(name) {
+      return `How are you, ${name}?`;
     }
     ```
+  - [6.5](#6.5) <a name='6.5'></a> Never use `eval()` on a string, it opens too many vulnerabilities.
 
 **[⬆ back to top](#table-of-contents)**
 
 
 ## Functions
 
-  - Function expressions:
+  - [7.1](#7.1) <a name='7.1'></a> Use function declarations instead of function expressions.
+
+    > Why? Function declarations are named, so they're easier to identify in call stacks. Also, the whole body of a function declaration is hoisted, whereas only the reference of a function expression is hoisted. This rule makes it possible to always use [Arrow Functions](#arrow-functions) in place of function expressions.
 
     ```javascript
-    // anonymous function expression
-    var anonymous = function() {
-      return true;
+    // bad
+    const foo = function () {
     };
 
-    // named function expression
-    var named = function named() {
-      return true;
-    };
+    // good
+    function foo() {
+    }
+    ```
 
+  - [7.2](#7.2) <a name='7.2'></a> Function expressions:
+
+    ```javascript
     // immediately-invoked function expression (IIFE)
-    (function() {
+    (() => {
       console.log('Welcome to the Internet. Please follow me.');
     })();
     ```
 
-  - Never declare a function in a non-function block (if, while, etc). Assign the function to a variable instead. Browsers will allow you to do it, but they all interpret it differently, which is bad news bears.
-  - **Note:** ECMA-262 defines a `block` as a list of statements. A function declaration is not a statement. [Read ECMA-262's note on this issue](http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf#page=97).
+  - [7.3](#7.3) <a name='7.3'></a> Never declare a function in a non-function block (if, while, etc). Assign the function to a variable instead. Browsers will allow you to do it, but they all interpret it differently, which is bad news bears.
+
+  - [7.4](#7.4) <a name='7.4'></a> **Note:** ECMA-262 defines a `block` as a list of statements. A function declaration is not a statement. [Read ECMA-262's note on this issue](http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf#page=97).
 
     ```javascript
     // bad
@@ -285,15 +526,15 @@
     }
 
     // good
-    var test;
+    let test;
     if (currentUser) {
-      test = function test() {
+      test = () => {
         console.log('Yup.');
       };
     }
     ```
 
-  - Never name a parameter `arguments`, this will take precedence over the `arguments` object that is given to every function scope.
+  - [7.5](#7.5) <a name='7.5'></a> Never name a parameter `arguments`. This will take precedence over the `arguments` object that is given to every function scope.
 
     ```javascript
     // bad
@@ -307,40 +548,455 @@
     }
     ```
 
+  <a name="es6-rest"></a>
+  - [7.6](#7.6) <a name='7.6'></a> Never use `arguments`, opt to use rest syntax `...` instead.
+
+    > Why? `...` is explicit about which arguments you want pulled. Plus rest arguments are a real Array and not Array-like like `arguments`.
+
+    ```javascript
+    // bad
+    function concatenateAll() {
+      const args = Array.prototype.slice.call(arguments);
+      return args.join('');
+    }
+
+    // good
+    function concatenateAll(...args) {
+      return args.join('');
+    }
+    ```
+
+  <a name="es6-default-parameters"></a>
+  - [7.7](#7.7) <a name='7.7'></a> Use default parameter syntax rather than mutating function arguments.
+
+    ```javascript
+    // really bad
+    function handleThings(opts) {
+      // No! We shouldn't mutate function arguments.
+      // Double bad: if opts is falsy it'll be set to an object which may
+      // be what you want but it can introduce subtle bugs.
+      opts = opts || {};
+      // ...
+    }
+
+    // still bad
+    function handleThings(opts) {
+      if (opts === void 0) {
+        opts = {};
+      }
+      // ...
+    }
+
+    // good
+    function handleThings(opts = {}) {
+      // ...
+    }
+    ```
+
+  - [7.8](#7.8) <a name='7.8'></a> Avoid side effects with default parameters.
+
+    > Why? They are confusing to reason about.
+
+    ```javascript
+    var b = 1;
+    // bad
+    function count(a = b++) {
+      console.log(a);
+    }
+    count();  // 1
+    count();  // 2
+    count(3); // 3
+    count();  // 3
+    ```
+
+  - [7.9](#7.9) <a name='7.9'></a> Always put default parameters last.
+
+    ```javascript
+    // bad
+    function handleThings(opts = {}, name) {
+      // ...
+    }
+
+    // good
+    function handleThings(name, opts = {}) {
+      // ...
+    }
+    ```
+
+  - [7.10](#7.10) <a name='7.10'></a> Never use the Function constructor to create a new function.
+
+    > Why? Creating a function in this way evaluates a string similarly to eval(), which opens vulnerabilities.
+
+    ```javascript
+    // bad
+    var add = new Function('a', 'b', 'return a + b');
+
+    // still bad
+    var subtract = Function('a', 'b', 'return a - b');
+    ```
+
+  - [7.11](#7.11) <a name="7.11"></a> Spacing in a function signature.
+
+    > Why? Consistency is good, and you shouldn’t have to add or remove a space when adding or removing a name.
+
+    ```javascript
+    // bad
+    const f = function(){};
+    const g = function (){};
+    const h = function() {};
+
+    // good
+    const x = function () {};
+    const y = function a() {};
+    ```
+
+  - [7.12](#7.12) <a name="7.12"></a> Never mutate parameters.
+
+    > Why? Manipulating objects passed in as parameters can cause unwanted variable side effects in the original caller.
+
+    eslint rules: [`no-param-reassign`](http://eslint.org/docs/rules/no-param-reassign.html).
+
+    ```javascript
+    // bad
+    function f1(obj) {
+      obj.key = 1;
+    };
+
+    // good
+    function f2(obj) {
+      const key = obj.key || 1;
+    };
+    ```
+
+  - [7.13](#7.13) <a name="7.13"></a> Never reassign parameters.
+
+    > Why? Reassigning parameters can lead to unexpected behavior, especially when accessing the `arguments` object. It can also cause optimization issues, especially in V8.
+
+    eslint rules: [`no-param-reassign`](http://eslint.org/docs/rules/no-param-reassign.html).
+
+    ```javascript
+    // bad
+    function f1(a) {
+      a = 1;
+    }
+
+    function f2(a) {
+      if (!a) { a = 1; }
+    }
+
+    // good
+    function f3(a) {
+      const b = a || 1;
+    }
+
+    function f4(a = 1) {
+    }
+    ```
+
 **[⬆ back to top](#table-of-contents)**
 
+## Arrow Functions
+
+  - [8.1](#8.1) <a name='8.1'></a> When you must use function expressions (as when passing an anonymous function), use arrow function notation.
+
+    > Why? It creates a version of the function that executes in the context of `this`, which is usually what you want, and is a more concise syntax.
+
+    > Why not? If you have a fairly complicated function, you might move that logic out into its own function declaration.
+
+    eslint rules: [`prefer-arrow-callback`](http://eslint.org/docs/rules/prefer-arrow-callback.html), [`arrow-spacing`](http://eslint.org/docs/rules/arrow-spacing.html).
+
+    ```javascript
+    // bad
+    [1, 2, 3].map(function (x) {
+      const y = x + 1;
+      return x * y;
+    });
+
+    // good
+    [1, 2, 3].map((x) => {
+      const y = x + 1;
+      return x * y;
+    });
+    ```
+
+  - [8.2](#8.2) <a name='8.2'></a> If the function body consists of a single expression, omit the braces and use the implicit return. Otherwise, keep the braces and use a `return` statement.
+
+    > Why? Syntactic sugar. It reads well when multiple functions are chained together.
+
+    > Why not? If you plan on returning an object.
+
+    eslint rules: [`arrow-parens`](http://eslint.org/docs/rules/arrow-parens.html), [`arrow-body-style`](http://eslint.org/docs/rules/arrow-body-style.html).
+
+    ```javascript
+    // good
+    [1, 2, 3].map(number => `A string containing the ${number}.`);
+
+    // bad
+    [1, 2, 3].map(number => {
+      const nextNumber = number + 1;
+      `A string containing the ${nextNumber}.`;
+    });
+
+    // good
+    [1, 2, 3].map(number => {
+      const nextNumber = number + 1;
+      return `A string containing the ${nextNumber}.`;
+    });
+    ```
+
+  - [8.3](#8.3) <a name='8.3'></a> In case the expression spans over multiple lines, wrap it in parentheses for better readability.
+
+    > Why? It shows clearly where the function starts and ends.
+
+    ```js
+    // bad
+    [1, 2, 3].map(number => 'As time went by, the string containing the ' +
+      `${number} became much longer. So we needed to break it over multiple ` +
+      'lines.'
+    );
+
+    // good
+    [1, 2, 3].map(number => (
+      `As time went by, the string containing the ${number} became much ` +
+      'longer. So we needed to break it over multiple lines.'
+    ));
+    ```
+
+
+  - [8.4](#8.4) <a name='8.4'></a> If your function takes a single argument and doesn’t use braces, omit the parentheses. Otherwise, always include parentheses around arguments.
+
+    > Why? Less visual clutter.
+
+    eslint rules: [`arrow-parens`](http://eslint.org/docs/rules/arrow-parens.html).
+
+    ```js
+    // bad
+    [1, 2, 3].map((x) => x * x);
+
+    // good
+    [1, 2, 3].map(x => x * x);
+
+    // good
+    [1, 2, 3].map(number => (
+      `A long string with the ${number}. It’s so long that we’ve broken it ` +
+      'over multiple lines!'
+    ));
+
+    // bad
+    [1, 2, 3].map(x => {
+      const y = x + 1;
+      return x * y;
+    });
+
+    // good
+    [1, 2, 3].map((x) => {
+      const y = x + 1;
+      return x * y;
+    });
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Constructors
+
+  - [9.2](#9.2) <a name='9.2'></a> Use `extends` for inheritance.
+
+    > Why? It is a built-in way to inherit prototype functionality without breaking `instanceof`.
+
+    ```javascript
+    // bad
+    const inherits = require('inherits');
+    function PeekableQueue(contents) {
+      Queue.apply(this, contents);
+    }
+    inherits(PeekableQueue, Queue);
+    PeekableQueue.prototype.peek = function () {
+      return this._queue[0];
+    }
+
+    // good
+    class PeekableQueue extends Queue {
+      peek() {
+        return this._queue[0];
+      }
+    }
+    ```
+
+### Class Methods
+
+  - [9.3](#9.3) <a name='9.3'></a> Methods can return `this` to help with method chaining.
+
+    ```javascript
+    // bad
+    Jedi.prototype.jump = function () {
+      this.jumping = true;
+      return true;
+    };
+
+    Jedi.prototype.setHeight = function (height) {
+      this.height = height;
+    };
+
+    const luke = new Jedi();
+    luke.jump(); // => true
+    luke.setHeight(20); // => undefined
+
+    // good
+    class Jedi {
+      jump() {
+        this.jumping = true;
+        return this;
+      }
+
+      setHeight(height) {
+        this.height = height;
+        return this;
+      }
+    }
+
+    const luke = new Jedi();
+
+    luke.jump()
+      .setHeight(20);
+    ```
+
+  - [9.4](#9.4) <a name='9.4'></a> Class methods should be bound in the constructor.
+
+    ```
+      // bad
+    class PeekableQueue extends Queue {
+      // babel outputs code that creates a new function in the constructor.
+      peek = () => {
+        return this._queue[0];
+      }
+    }
+
+      // good
+    class PeekableQueue extends Queue {
+      constructor() {
+        this.peek = this.peek.bind(this);
+      }
+
+      peek() {
+        return this._queue[0];
+      }
+    }
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+## Modules
+
+  - [10.1](#10.1) <a name='10.1'></a> Always use modules (`import`/`export`) over a non-standard module system. You can always transpile to your preferred module system.
+
+    > Why? Modules are the future, let's start using the future now.
+
+    ```javascript
+    // bad
+    const AirbnbStyleGuide = require('./AirbnbStyleGuide');
+    module.exports = AirbnbStyleGuide.es6;
+
+    // best
+    import { es6 } from './AirbnbStyleGuide';
+    export default es6;
+    ```
+
+  - [10.2](#10.2) <a name='10.2'></a> Do not use wildcard imports.
+
+    > Why? This makes sure you have a single default export.
+
+    ```javascript
+    // bad
+    import * as AirbnbStyleGuide from './AirbnbStyleGuide';
+
+    // good
+    import AirbnbStyleGuide from './AirbnbStyleGuide';
+    ```
+
+  - [10.3](#10.3) <a name='10.3'></a>And do not export directly from an import.
+
+    > Why? Although the one-liner is concise, having one clear way to import and one clear way to export makes things consistent.
+
+    ```javascript
+    // bad
+    // filename es6.js
+    export { es6 as default } from './airbnbStyleGuide';
+
+    // good
+    // filename es6.js
+    import { es6 } from './AirbnbStyleGuide';
+    export default es6;
+    ```
+
+  - [10.4](#10.4) <a name='10.4'></a> Files should generally only export one class or function.
+
+**[⬆ back to top](#table-of-contents)**
+
+## Iterators and Generators
+
+  - [11.1](#11.1) <a name='11.1'></a> Don't use iterators. Prefer JavaScript's higher-order functions like `map()` and `reduce()` instead of loops like `for-of`.
+
+    > Why? This enforces our immutable rule. Dealing with pure functions that return values is easier to reason about than side-effects.
+
+    eslint rules: [`no-iterator`](http://eslint.org/docs/rules/no-iterator.html).
+
+    ```javascript
+    const numbers = [1, 2, 3, 4, 5];
+
+    // bad
+    let sum = 0;
+    for (let num of numbers) {
+      sum += num;
+    }
+
+    sum === 15;
+
+    // good
+    let sum = 0;
+    numbers.forEach((num) => sum += num);
+    sum === 15;
+
+    // best (use the functional force)
+    const sum = numbers.reduce((total, num) => total + num, 0);
+    sum === 15;
+    ```
+
+**[⬆ back to top](#table-of-contents)**
 
 
 ## Properties
 
-  - Use dot notation when accessing properties.
+  - [12.1](#12.1) <a name='12.1'></a> Use dot notation when accessing properties.
+
+    eslint rules: [`dot-notation`](http://eslint.org/docs/rules/dot-notation.html).
 
     ```javascript
-    var luke = {
+    const luke = {
       jedi: true,
-      age: 28
+      age: 28,
     };
 
     // bad
-    var isJedi = luke['jedi'];
+    const isJedi = luke['jedi'];
 
     // good
-    var isJedi = luke.jedi;
+    const isJedi = luke.jedi;
     ```
 
-  - Use subscript notation `[]` when accessing properties with a variable.
+  - [12.2](#12.2) <a name='12.2'></a> Use subscript notation `[]` when accessing properties with a variable.
 
     ```javascript
-    var luke = {
+    const luke = {
       jedi: true,
-      age: 28
+      age: 28,
     };
 
     function getProp(prop) {
       return luke[prop];
     }
 
-    var isJedi = getProp('jedi');
+    const isJedi = getProp('jedi');
     ```
 
 **[⬆ back to top](#table-of-contents)**
@@ -348,79 +1004,78 @@
 
 ## Variables
 
-  - Always use `var` to declare variables. Not doing so will result in global variables. We want to avoid polluting the global namespace. Captain Planet warned us of that.
+  - [13.1](#13.1) <a name='13.1'></a> Always use `const` to declare variables. Not doing so will result in global variables. We want to avoid polluting the global namespace. Captain Planet warned us of that.
 
     ```javascript
     // bad
     superPower = new SuperPower();
 
     // good
-    var superPower = new SuperPower();
+    const superPower = new SuperPower();
     ```
 
-  - Use multiple `var` declarations for multiple variables and declare each variable on a newline.
+  - [13.2](#13.2) <a name='13.2'></a> Use one `const` declaration per variable.
+
+    > Why? It's easier to add new variable declarations this way, and you never have to worry about swapping out a `;` for a `,` or introducing punctuation-only diffs.
+
+    eslint rules: [`one-var`](http://eslint.org/docs/rules/one-var.html).
 
     ```javascript
     // bad
-    var items = getItems(),
+    const items = getItems(),
         goSportsTeam = true,
         dragonball = 'z';
 
+    // bad
+    // (compare to above, and try to spot the mistake)
+    const items = getItems(),
+        goSportsTeam = true;
+        dragonball = 'z';
+
     // good
-    var items = getItems();
-    var goSportsTeam = true;
-    var dragonball = 'z';
+    const items = getItems();
+    const goSportsTeam = true;
+    const dragonball = 'z';
     ```
 
-  - Declare unassigned variables last. This is helpful when later on you might need to assign a variable depending on one of the previous assigned variables.
+  - [13.3](#13.3) <a name='13.3'></a> Group all your `const`s and then group all your `let`s.
+
+    > Why? This is helpful when later on you might need to assign a variable depending on one of the previous assigned variables.
 
     ```javascript
     // bad
-    var i, len, dragonball,
+    let i, len, dragonball,
         items = getItems(),
         goSportsTeam = true;
 
     // bad
-    var i, items = getItems(),
-        dragonball,
-        goSportsTeam = true,
-        len;
+    let i;
+    const items = getItems();
+    let dragonball;
+    const goSportsTeam = true;
+    let len;
 
     // good
-    var items = getItems();
-    var goSportsTeam = true;
-    var dragonball;
-    var length;
-    var i;
+    const goSportsTeam = true;
+    const items = getItems();
+    let dragonball;
+    let i;
+    let length;
     ```
 
-  - Assign variables at the top of their scope. This helps avoid issues with variable declaration and assignment hoisting related issues.
+  - [13.4](#13.4) <a name='13.4'></a> Assign variables where you need them, but place them in a reasonable place.
+
+    > Why? `let` and `const` are block scoped and not function scoped.
 
     ```javascript
-    // bad
-    function() {
-      test();
-      console.log('doing stuff..');
-
-      //..other stuff..
-
-      var name = getName();
-
-      if (name === 'test') {
-        return false;
-      }
-
-      return name;
-    }
-
     // good
-    function() {
-      var name = getName();
-
+    function () {
       test();
       console.log('doing stuff..');
 
       //..other stuff..
+
+      const name = getName();
 
       if (name === 'test') {
         return false;
@@ -429,24 +1084,27 @@
       return name;
     }
 
-    // bad
-    function() {
-      var name = getName();
+    // bad - unnecessary function call
+    function (hasName) {
+      const name = getName();
 
-      if (!arguments.length) {
+      if (!hasName) {
         return false;
       }
+
+      this.setFirstName(name);
 
       return true;
     }
 
     // good
-    function() {
-      if (!arguments.length) {
+    function (hasName) {
+      if (!hasName) {
         return false;
       }
 
-      var name = getName();
+      const name = getName();
+      this.setFirstName(name);
 
       return true;
     }
@@ -457,7 +1115,7 @@
 
 ## Hoisting
 
-  - Variable declarations get hoisted to the top of their scope, their assignment does not.
+  - [14.1](#14.1) <a name='14.1'></a> `var` declarations get hoisted to the top of their scope, their assignment does not. `const` and `let` declarations are blessed with a new concept called [Temporal Dead Zones (TDZ)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone_and_errors_with_let). It's important to know why [typeof is no longer safe](http://es-discourse.com/t/why-typeof-is-no-longer-safe/15).
 
     ```javascript
     // we know this wouldn't work (assuming there
@@ -476,16 +1134,23 @@
     }
 
     // The interpreter is hoisting the variable
-    // declaration to the top of the scope.
-    // Which means our example could be rewritten as:
+    // declaration to the top of the scope,
+    // which means our example could be rewritten as:
     function example() {
       var declaredButNotAssigned;
       console.log(declaredButNotAssigned); // => undefined
       declaredButNotAssigned = true;
     }
+
+    // using const and let
+    function example() {
+      console.log(declaredButNotAssigned); // => throws a ReferenceError
+      console.log(typeof declaredButNotAssigned); // => throws a ReferenceError
+      const declaredButNotAssigned = true;
+    }
     ```
 
-  - Anonymous function expressions hoist their variable name, but not the function assignment.
+  - [14.2](#14.2) <a name='14.2'></a> Anonymous function expressions hoist their variable name, but not the function assignment.
 
     ```javascript
     function example() {
@@ -493,13 +1158,13 @@
 
       anonymous(); // => TypeError anonymous is not a function
 
-      var anonymous = function() {
+      var anonymous = function () {
         console.log('anonymous function expression');
       };
     }
     ```
 
-  - Named function expressions hoist the variable name, not the function name or the function body.
+  - [14.3](#14.3) <a name='14.3'></a> Named function expressions hoist the variable name, not the function name or the function body.
 
     ```javascript
     function example() {
@@ -527,7 +1192,7 @@
     }
     ```
 
-  - Function declarations hoist their name and the function body.
+  - [14.4](#14.4) <a name='14.4'></a> Function declarations hoist their name and the function body.
 
     ```javascript
     function example() {
@@ -539,16 +1204,18 @@
     }
     ```
 
-  - For more information refer to [JavaScript Scoping & Hoisting](http://www.adequatelygood.com/2010/2/JavaScript-Scoping-and-Hoisting) by [Ben Cherry](http://www.adequatelygood.com/)
+  - For more information refer to [JavaScript Scoping & Hoisting](http://www.adequatelygood.com/2010/2/JavaScript-Scoping-and-Hoisting/) by [Ben Cherry](http://www.adequatelygood.com/).
 
 **[⬆ back to top](#table-of-contents)**
 
 
+## Comparison Operators & Equality
 
-## Conditional Expressions & Equality
+  - [15.1](#15.1) <a name='15.1'></a> Use `===` and `!==` over `==` and `!=`.
 
-  - Use `===` and `!==` over `==` and `!=`.
-  - Conditional expressions are evaluated using coercion with the `ToBoolean` method and always follow these simple rules:
+  - [15.2](#15.2) <a name='15.2'></a> Conditional statements such as the `if` statement evaluate their expression using coercion with the `ToBoolean` abstract method and always follow these simple rules:
+
+    eslint rules: [`eqeqeq`](http://eslint.org/docs/rules/eqeqeq.html).
 
     + **Objects** evaluate to **true**
     + **Undefined** evaluates to **false**
@@ -564,7 +1231,7 @@
     }
     ```
 
-  - Use shortcuts.
+  - [15.3](#15.3) <a name='15.3'></a> Use shortcuts.
 
     ```javascript
     // bad
@@ -588,46 +1255,19 @@
     }
     ```
 
-  - For more information see [Truth Equality and JavaScript](http://javascriptweblog.wordpress.com/2011/02/07/truth-equality-and-javascript/#more-2108) by Angus Croll
-
-  - Put your curly braces on the same line for `else` / `else if`s.
-
-    ```javascript
-    //bad
-    if (name === 'jane') {
-      // ...stuff
-    }
-    else if (name === 'bob') {
-      // ...stuff
-    }
-    else {
-      // ...stuff
-    }
-
-    //good
-    if (name === 'jane') {
-      // ...stuff
-    } else if (name === 'bob') {
-      // ...stuff
-    } else {
-      // ...stuff
-    }
-    ```
+  - [15.4](#15.4) <a name='15.4'></a> For more information see [Truth Equality and JavaScript](http://javascriptweblog.wordpress.com/2011/02/07/truth-equality-and-javascript/#more-2108) by Angus Croll.
 
 **[⬆ back to top](#table-of-contents)**
 
 
 ## Blocks
 
-  - Use braces. Single-line functions are okay if short. Single-line conditionals are okay if short.
+  - [16.1](#16.1) <a name='16.1'></a> Use braces. Single-line functions are okay if short. Single-line conditionals are okay if short.
 
     ```javascript
     // bad
     if (test)
       return false;
-
-    // bad
-    if (test) return false;
 
     // good
     if (test) { return false; }
@@ -637,29 +1277,63 @@
       return false;
     }
 
-    // good
-    function() { return false; }
+    // bad
+    function () { return false; }
 
     // good
-    function() {
+    function () {
       return false;
     }
     ```
+
+  - [16.2](#16.2) <a name='16.2'></a> If you're using multi-line blocks with `if` and `else`, put `else` on the same line as your
+    `if` block's closing brace.
+
+    eslint rules: [`brace-style`](http://eslint.org/docs/rules/brace-style.html).
+
+    ```javascript
+    // bad
+    if (test) {
+      thing1();
+      thing2();
+    }
+    else {
+      thing3();
+    }
+
+    // good
+    if (test) {
+      thing1();
+      thing2();
+    } else {
+      thing3();
+    }
+    ```
+  - [16.3](#16.3) <a name='16.3'></a> Try not to get too clever with the syntax you use for control flow.
+
+  ```javascript
+  // bad
+  let country = canGeotarget && $('#country').val() || '';
+
+  // better. ternaries are fine for single lines. no nesting please.
+  let country = canGeotarget ? $('#country').val() : '';
+  ```
+
 
 **[⬆ back to top](#table-of-contents)**
 
 
 ## Comments
 
-  - Use `/** ... */` for docstring comments. Include a description, specify types and values for all parameters and return values.
+  - [17.1](#17.1) <a name='17.1'></a> Use `/** ... */` for docstring comments. Include a description, specify types and values for all parameters and return values.
 
     ```javascript
     // bad
     // make() returns a new element
     // based on the passed in tag name
     //
-    // @param <String> tag
-    // @return <Element> element
+    // @param {String} tag
+    // @return {Element} element
     function make(tag) {
 
       // ...stuff...
@@ -672,8 +1346,8 @@
      * make() returns a new element
      * based on the passed in tag name
      *
-     * @param <String> tag
-     * @return <Element> element
+     * @param {String} tag
+     * @return {Element} element
      */
     function make(tag) {
 
@@ -683,21 +1357,21 @@
     }
     ```
 
-  - Use `//` for single line comments and multi-line comments that aren't docstrings. Place single line comments on a newline above the subject of the comment. Put an empty line before the comment.
+  - [17.2](#17.2) <a name='17.2'></a> Use `//` for single line comments and multi-line comments that arent docstrings. Place single line comments on a newline above the subject of the comment. Put an empty line before the comment unless it's on the first line of a block.
 
     ```javascript
     // bad
-    var active = true;  // is current tab
+    const active = true;  // is current tab
 
     // good
     // is current tab
-    var active = true;
+    const active = true;
 
     // bad
     function getType() {
       console.log('fetching type...');
       // set the default type to 'no type'
-      var type = this._type || 'no type';
+      const type = this._type || 'no type';
 
       return type;
     }
@@ -707,63 +1381,77 @@
       console.log('fetching type...');
 
       // set the default type to 'no type'
-      var type = this._type || 'no type';
+      const type = this._type || 'no type';
+
+      return type;
+    }
+
+    // also good
+    function getType() {
+      // set the default type to 'no type'
+      const type = this._type || 'no type';
 
       return type;
     }
     ```
 
-  - Prefixing your comments with `FIXME` or `TODO` helps other developers quickly understand if you're pointing out a problem that needs to be revisited, or if you're suggesting a solution to the problem that needs to be implemented. These are different than regular comments because they are actionable. The actions are `FIXME -- need to figure this out` or `TODO -- need to implement`.
+  - [17.3](#17.3) <a name='17.3'></a> Prefixing your comments with `FIXME` or `TODO` helps other developers quickly understand if you're pointing out a problem that needs to be revisited, or if you're suggesting a solution to the problem that needs to be implemented. These are different than regular comments because they are actionable. The actions are `FIXME -- need to figure this out` or `TODO -- need to implement`.
 
-  - Use `// FIXME:` to annotate problems
+  - [17.4](#17.4) <a name='17.4'></a> Use `// FIXME:` to annotate problems.
 
     ```javascript
-    function Calculator() {
+    class Calculator extends Abacus {
+      constructor() {
+        super();
 
-      // FIXME: shouldn't use a global here
-      total = 0;
-
-      return this;
+        // FIXME: shouldn't use a global here
+        total = 0;
+      }
     }
     ```
 
-  - Use `// TODO:` to annotate solutions to problems
+  - [17.5](#17.5) <a name='17.5'></a> Use `// TODO:` to annotate solutions to problems.
 
     ```javascript
-    function Calculator() {
+    class Calculator extends Abacus {
+      constructor() {
+        super();
 
-      // TODO: total should be configurable by an options param
-      this.total = 0;
-
-      return this;
+        // TODO: total should be configurable by an options param
+        this.total = 0;
+      }
     }
-  ```
+    ```
 
 **[⬆ back to top](#table-of-contents)**
 
 
 ## Whitespace
 
-  - Use soft tabs set to 2 spaces
+  - [18.1](#18.1) <a name='18.1'></a> Use soft tabs set to 2 spaces.
+
+    eslint rules: [`indent`](http://eslint.org/docs/rules/indent.html).
 
     ```javascript
     // bad
-    function() {
-    ∙∙∙∙var name;
+    function () {
+    ∙∙∙∙const name;
     }
 
     // bad
-    function() {
-    ∙var name;
+    function () {
+    ∙const name;
     }
 
     // good
-    function() {
-    ∙∙var name;
+    function () {
+    ∙∙const name;
     }
     ```
 
-  - Place 1 space before the leading brace.
+  - [18.2](#18.2) <a name='18.2'></a> Place 1 space before the leading brace.
+
+    eslint rules: [`space-before-blocks`](http://eslint.org/docs/rules/space-before-blocks.html).
 
     ```javascript
     // bad
@@ -779,55 +1467,92 @@
     // bad
     dog.set('attr',{
       age: '1 year',
-      breed: 'Bernese Mountain Dog'
+      breed: 'Bernese Mountain Dog',
     });
 
     // good
     dog.set('attr', {
       age: '1 year',
-      breed: 'Bernese Mountain Dog'
+      breed: 'Bernese Mountain Dog',
     });
     ```
 
-  - Set off operators with spaces.
+  - [18.3](#18.3) <a name='18.3'></a> Place 1 space before the opening parenthesis in control statements (`if`, `while` etc.). Place no space before the argument list in function calls and declarations.
+
+    eslint rules: [`space-after-keywords`](http://eslint.org/docs/rules/space-after-keywords.html), [`space-before-keywords`](http://eslint.org/docs/rules/space-before-keywords.html).
 
     ```javascript
     // bad
-    var x=y+5;
+    if(isJedi) {
+      fight ();
+    }
 
     // good
-    var x = y + 5;
-    ```
+    if (isJedi) {
+      fight();
+    }
 
-  - Files should end with a single newline character.
+    // bad
+    function fight () {
+      console.log ('Swooosh!');
+    }
 
-    ```javascript
     // good
-    (function(global) {
-      // ...stuff...
-    })(this);↵
+    function fight() {
+      console.log('Swooosh!');
+    }
     ```
+
+  - [18.4](#18.4) <a name='18.4'></a> Set off operators with spaces.
+
+    eslint rules: [`space-infix-ops`](http://eslint.org/docs/rules/space-infix-ops.html).
 
     ```javascript
     // bad
-    (function(global) {
+    const x=y+5;
+
+    // good
+    const x = y + 5;
+    ```
+
+  - [18.5](#18.5) <a name='18.5'></a> End files with a single newline character.
+
+    ```javascript
+    // bad
+    (function (global) {
       // ...stuff...
     })(this);
     ```
 
     ```javascript
     // bad
-    (function(global) {
+    (function (global) {
       // ...stuff...
-    })(this)↵
+    })(this);↵
     ↵
     ```
 
-  - Use indentation when making long method chains.
+    ```javascript
+    // good
+    (function (global) {
+      // ...stuff...
+    })(this);↵
+    ```
+
+  - [18.6](#18.6) <a name='18.6'></a> Use indentation when making long method chains. Use a leading dot, which
+    emphasizes that the line is a method call, not a new statement.
 
     ```javascript
     // bad
     $('#items').find('.selected').highlight().end().find('.open').updateCount();
+
+    // bad
+    $('#items').
+      find('.selected').
+        highlight().
+        end().
+      find('.open').
+        updateCount();
 
     // good
     $('#items')
@@ -838,81 +1563,272 @@
         .updateCount();
 
     // bad
-    var leds = stage.selectAll('.led').data(data).enter().append('svg:svg').class('led', true)
-        .attr('width',  (radius + margin) * 2).append('svg:g')
+    const leds = stage.selectAll('.led').data(data).enter().append('svg:svg').class('led', true)
+        .attr('width', (radius + margin) * 2).append('svg:g')
         .attr('transform', 'translate(' + (radius + margin) + ',' + (radius + margin) + ')')
         .call(tron.led);
 
     // good
-    var leds = stage.selectAll('.led')
+    const leds = stage.selectAll('.led')
         .data(data)
       .enter().append('svg:svg')
-        .class('led', true)
-        .attr('width',  (radius + margin) * 2)
+        .classed('led', true)
+        .attr('width', (radius + margin) * 2)
       .append('svg:g')
         .attr('transform', 'translate(' + (radius + margin) + ',' + (radius + margin) + ')')
         .call(tron.led);
+    ```
+
+  - [18.7](#18.7) <a name='18.7'></a> Leave a blank line after blocks and before the next statement.
+
+    ```javascript
+    // bad
+    if (foo) {
+      return bar;
+    }
+    return baz;
+
+    // good
+    if (foo) {
+      return bar;
+    }
+
+    return baz;
+
+    // bad
+    const obj = {
+      foo() {
+      },
+      bar() {
+      },
+    };
+    return obj;
+
+    // good
+    const obj = {
+      foo() {
+      },
+
+      bar() {
+      },
+    };
+
+    return obj;
+
+    // bad
+    const arr = [
+      function foo() {
+      },
+      function bar() {
+      },
+    ];
+    return arr;
+
+    // good
+    const arr = [
+      function foo() {
+      },
+
+      function bar() {
+      },
+    ];
+
+    return arr;
+    ```
+
+  - [18.8](#18.8) <a name='18.8'></a> Do not pad your blocks with blank lines.
+
+    eslint rules: [`padded-blocks`](http://eslint.org/docs/rules/padded-blocks.html).
+
+    ```javascript
+    // bad
+    function bar() {
+
+      console.log(foo);
+
+    }
+
+    // also bad
+    if (baz) {
+
+      console.log(qux);
+    } else {
+      console.log(foo);
+
+    }
+
+    // good
+    function bar() {
+      console.log(foo);
+    }
+
+    // good
+    if (baz) {
+      console.log(qux);
+    } else {
+      console.log(foo);
+    }
+    ```
+
+  - [18.9](#18.9) <a name='18.9'></a> Do not add spaces inside parentheses.
+
+    eslint rules: [`space-in-parens`](http://eslint.org/docs/rules/space-in-parens.html).
+
+    ```javascript
+    // bad
+    function bar( foo ) {
+      return foo;
+    }
+
+    // good
+    function bar(foo) {
+      return foo;
+    }
+
+    // bad
+    if ( foo ) {
+      console.log(foo);
+    }
+
+    // good
+    if (foo) {
+      console.log(foo);
+    }
+    ```
+
+  - [18.10](#18.10) <a name='18.10'></a> Do not add spaces inside brackets.
+
+    eslint rules: [`array-bracket-spacing`](http://eslint.org/docs/rules/array-bracket-spacing.html).
+
+    ```javascript
+    // bad
+    const foo = [ 1, 2, 3 ];
+    console.log(foo[ 0 ]);
+
+    // good
+    const foo = [1, 2, 3];
+    console.log(foo[0]);
+    ```
+
+  - [18.11](#18.11) <a name='18.11'></a> Add spaces inside curly braces.
+
+    eslint rules: [`object-curly-spacing`](http://eslint.org/docs/rules/object-curly-spacing.html).
+
+    ```javascript
+    // bad
+    const foo = {clark: 'kent'};
+
+    // good
+    const foo = { clark: 'kent' };
+    ```
+
+  - [18.12](#18.12) <a name='18.12'></a> Avoid having lines of code that are longer than 100 characters (including whitespace).
+
+    > Why? This ensures readability and maintainability.
+
+    eslint rules: [`max-len`](http://eslint.org/docs/rules/max-len.html).
+
+    ```javascript
+    // bad
+    const foo = 'Whatever national crop flips the window. The cartoon reverts within the screw. Whatever wizard constrains a helpful ally. The counterpart ascends!';
+
+    // bad
+    $.ajax({ method: 'POST', url: 'https://airbnb.com/', data: { name: 'John' } }).done(() => console.log('Congratulations!')).fail(() => console.log('You have failed this city.'));
+
+    // good
+    const foo = 'Whatever national crop flips the window. The cartoon reverts within the screw. ' +
+      'Whatever wizard constrains a helpful ally. The counterpart ascends!';
+
+    // good
+    $.ajax({
+      method: 'POST',
+      url: 'https://airbnb.com/',
+      data: { name: 'John' },
+    })
+      .done(() => console.log('Congratulations!'))
+      .fail(() => console.log('You have failed this city.'));
     ```
 
 **[⬆ back to top](#table-of-contents)**
 
 ## Commas
 
-  - Leading commas: **Nope.**
+  - [19.1](#19.1) <a name='19.1'></a> Leading commas: **Nope.**
+
+    eslint rules: [`comma-style`](http://eslint.org/docs/rules/comma-style.html).
 
     ```javascript
     // bad
-    var once
+    const story = [
+        once
       , upon
-      , aTime;
+      , aTime
+    ];
 
     // good
-    var once = [
-      'upon',
-      'a',
-      'time'
-    ]
+    const story = [
+      once,
+      upon,
+      aTime,
+    ];
 
     // bad
-    var hero = {
-        firstName: 'Bob'
-      , lastName: 'Parr'
-      , heroName: 'Mr. Incredible'
-      , superPower: 'strength'
+    const hero = {
+        firstName: 'Ada'
+      , lastName: 'Lovelace'
+      , birthYear: 1815
+      , superPower: 'computers'
     };
 
     // good
-    var hero = {
-      firstName: 'Bob',
-      lastName: 'Parr',
-      heroName: 'Mr. Incredible',
-      superPower: 'strength'
+    const hero = {
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      birthYear: 1815,
+      superPower: 'computers',
     };
     ```
 
-  - Additional trailing comma: **Yup.** Our Javascript is run through a compiler, and we're not terribly worried about IE < 9 support. This makes diffs cleaner. This was clarified in ES5 ([source](http://es5.github.io/#D)):
+  - [19.2](#19.2) <a name='19.2'></a> Additional trailing comma: **Yup.**
 
-  > Edition 5 clarifies the fact that a trailing comma at the end of an ArrayInitialiser does not add to the length of the array. This is not a semantic change from Edition 3 but some implementations may have previously misinterpreted this.
+    eslint rules: [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle.html).
+
+    > Why? This leads to cleaner git diffs. Also, transpilers like Babel will remove the additional trailing comma in the transpiled code which means you don't have to worry about the [trailing comma problem](es5/README.md#commas) in legacy browsers.
 
     ```javascript
-    // bad
-    var hero = {
-      firstName: 'Kevin',
-      lastName: 'Flynn'
+    // bad - git diff without trailing comma
+    const hero = {
+         firstName: 'Florence',
+    -    lastName: 'Nightingale'
+    +    lastName: 'Nightingale',
+    +    inventorOf: ['coxcomb graph', 'modern nursing']
     };
 
-    var heroes = [
+    // good - git diff with trailing comma
+    const hero = {
+         firstName: 'Florence',
+         lastName: 'Nightingale',
+    +    inventorOf: ['coxcomb chart', 'modern nursing'],
+    };
+
+    // bad
+    const hero = {
+      firstName: 'Dana',
+      lastName: 'Scully'
+    };
+
+    const heroes = [
       'Batman',
       'Superman'
     ];
 
     // good
-    var hero = {
-      firstName: 'Kevin',
-      lastName: 'Flynn',
+    const hero = {
+      firstName: 'Dana',
+      lastName: 'Scully',
     };
 
-    var heroes = [
+    const heroes = [
       'Batman',
       'Superman',
     ];
@@ -923,78 +1839,75 @@
 
 ## Semicolons
 
-  - **Yup.**
+  - [20.1](#20.1) <a name='20.1'></a> **Yup.**
+
+    eslint rules: [`semi`](http://eslint.org/docs/rules/semi.html).
 
     ```javascript
     // bad
-    (function() {
-      var name = 'Skywalker'
+    (function () {
+      const name = 'Skywalker'
       return name
     })()
 
     // good
-    (function() {
-      var name = 'Skywalker';
+    (() => {
+      const name = 'Skywalker';
       return name;
     })();
 
-    // good
-    ;(function() {
-      var name = 'Skywalker';
+    // good (guards against the function becoming an argument when two files with IIFEs are concatenated)
+    ;(() => {
+      const name = 'Skywalker';
       return name;
     })();
     ```
+
+    [Read more](http://stackoverflow.com/questions/7365172/semicolon-before-self-invoking-function/7365214%237365214).
 
 **[⬆ back to top](#table-of-contents)**
 
 
 ## Type Casting & Coercion
 
-  - Perform type coercion at the beginning of the statement.
-  - Strings:
+  - [21.1](#21.1) <a name='21.1'></a> Perform type coercion at the beginning of the statement.
+  - [21.2](#21.2) <a name='21.2'></a> Strings:
 
     ```javascript
     //  => this.reviewScore = 9;
 
     // bad
-    var totalScore = this.reviewScore + '';
+    const totalScore = this.reviewScore + '';
 
     // good
-    var totalScore = '' + this.reviewScore;
-
-    // bad
-    var totalScore = '' + this.reviewScore + ' total score';
-
-    // good
-    var totalScore = this.reviewScore + ' total score';
+    const totalScore = String(this.reviewScore);
     ```
 
-  - Use `parseInt` for Numbers and always with a radix for type casting.
+  - [21.3](#21.3) <a name='21.3'></a> Numbers: Use `Number` for type casting and `parseInt` always with a radix for parsing strings.
 
     ```javascript
-    var inputValue = '4';
+    const inputValue = '4';
 
     // bad
-    var val = new Number(inputValue);
+    const val = new Number(inputValue);
 
     // bad
-    var val = +inputValue;
+    const val = +inputValue;
 
     // bad
-    var val = inputValue >> 0;
+    const val = inputValue >> 0;
 
     // bad
-    var val = parseInt(inputValue);
+    const val = parseInt(inputValue);
 
     // good
-    var val = Number(inputValue);
+    const val = Number(inputValue);
 
     // good
-    var val = parseInt(inputValue, 10);
+    const val = parseInt(inputValue, 10);
     ```
 
-  - If for whatever reason you are doing something wild and `parseInt` is your bottleneck and need to use Bitshift for [performance reasons](http://jsperf.com/coercion-vs-casting/3), leave a comment explaining why and what you're doing.
-  - **Note:** Be careful when using bitshift operations. Numbers are represented as [64-bit values](http://es5.github.io/#x4.3.19), but Bitshift operations always return a 32-bit integer ([source](http://es5.github.io/#x11.7)). Bitshift can lead to unexpected behavior for integer values larger than 32 bits. [Discussion](https://github.com/airbnb/javascript/issues/109)
+  - [21.4](#21.4) <a name='21.4'></a> If for whatever reason you are doing something wild and `parseInt` is your bottleneck and need to use Bitshift for [performance reasons](http://jsperf.com/coercion-vs-casting/3), leave a comment explaining why and what you're doing.
 
     ```javascript
     // good
@@ -1003,22 +1916,30 @@
      * Bitshifting the String to coerce it to a
      * Number made it a lot faster.
      */
-    var val = inputValue >> 0;
+    const val = inputValue >> 0;
     ```
 
-  - Booleans:
+  - [21.5](#21.5) <a name='21.5'></a> **Note:** Be careful when using bitshift operations. Numbers are represented as [64-bit values](http://es5.github.io/#x4.3.19), but Bitshift operations always return a 32-bit integer ([source](http://es5.github.io/#x11.7)). Bitshift can lead to unexpected behavior for integer values larger than 32 bits. [Discussion](https://github.com/airbnb/javascript/issues/109). Largest signed 32-bit Int is 2,147,483,647:
 
     ```javascript
-    var age = 0;
+    2147483647 >> 0 //=> 2147483647
+    2147483648 >> 0 //=> -2147483648
+    2147483649 >> 0 //=> -2147483647
+    ```
+
+  - [21.6](#21.6) <a name='21.6'></a> Booleans:
+
+    ```javascript
+    const age = 0;
 
     // bad
-    var hasAge = new Boolean(age);
+    const hasAge = new Boolean(age);
 
     // good
-    var hasAge = Boolean(age);
+    const hasAge = Boolean(age);
 
     // good
-    var hasAge = !!age;
+    const hasAge = !!age;
     ```
 
 **[⬆ back to top](#table-of-contents)**
@@ -1026,7 +1947,7 @@
 
 ## Naming Conventions
 
-  - Avoid single letter names. Be descriptive with your naming.
+  - [22.1](#22.1) <a name='22.1'></a> Avoid single letter names. Be descriptive with your naming.
 
     ```javascript
     // bad
@@ -1040,26 +1961,22 @@
     }
     ```
 
-  - Use camelCase when naming objects, functions, and instances
+  - [22.2](#22.2) <a name='22.2'></a> Use camelCase when naming objects, functions, and instances.
+
+    eslint rules: [`camelcase`](http://eslint.org/docs/rules/camelcase.html).
 
     ```javascript
     // bad
-    var OBJEcttsssss = {};
-    var this_is_my_object = {};
-    function c() {};
-    var u = new user({
-      name: 'Bob Parr'
-    });
+    const OBJEcttsssss = {};
+    const this_is_my_object = {};
+    function c() {}
 
     // good
-    var thisIsMyObject = {};
-    function thisIsMyFunction() {};
-    var user = new User({
-      name: 'Bob Parr'
-    });
+    const thisIsMyObject = {};
+    function thisIsMyFunction() {}
     ```
 
-  - Use PascalCase when naming constructors or classes
+  - [22.3](#22.3) <a name='22.3'></a> Use PascalCase when naming constructors or classes.
 
     ```javascript
     // bad
@@ -1067,80 +1984,97 @@
       this.name = options.name;
     }
 
-    var bad = new user({
-      name: 'nope'
+    const bad = new user({
+      name: 'nope',
     });
 
     // good
-    function User(options) {
-      this.name = options.name;
+    class User {
+      constructor(options) {
+        this.name = options.name;
+      }
     }
 
-    var good = new User({
-      name: 'yup'
+    const good = new User({
+      name: 'yup',
     });
     ```
 
-  - Use a leading underscore `_` when naming private properties
+  - [22.5](#22.5) <a name='22.5'></a> Don't save references to `this`. Use arrow functions or Function#bind.
 
     ```javascript
     // bad
-    this.__firstName__ = 'Panda';
-    this.firstName_ = 'Panda';
-
-    // good
-    this._firstName = 'Panda';
-    ```
-
-  - When saving a reference to `this` use `_this`.
-
-    ```javascript
-    // bad
-    function() {
-      var self = this;
-      return function() {
+    function foo() {
+      const self = this;
+      return function () {
         console.log(self);
       };
     }
 
     // bad
-    function() {
-      var that = this;
-      return function() {
+    function foo() {
+      const that = this;
+      return function () {
         console.log(that);
       };
     }
 
     // good
-    function() {
-      var _this = this;
-      return function() {
-        console.log(_this);
+    function foo() {
+      return () => {
+        console.log(this);
       };
     }
     ```
 
-  - Name your functions. This is helpful for stack traces.
+  - [22.6](#22.6) <a name='22.6'></a> If your file exports a single class, your filename should be exactly the name of the class.
 
     ```javascript
+    // file contents
+    class CheckBox {
+      // ...
+    }
+    export default CheckBox;
+
+    // in some other file
     // bad
-    var log = function(msg) {
-      console.log(msg);
-    };
+    import CheckBox from './checkBox';
+
+    // bad
+    import CheckBox from './check_box';
 
     // good
-    var log = function log(msg) {
-      console.log(msg);
-    };
+    import CheckBox from './CheckBox';
     ```
+
+  - [22.7](#22.7) <a name='22.7'></a> Use camelCase when you export-default a function. Your filename should be identical to your function's name.
+
+    ```javascript
+    function makeStyleGuide() {
+    }
+
+    export default makeStyleGuide;
+    ```
+
+  - [22.8](#22.8) <a name='22.8'></a> Use PascalCase when you export a singleton / function library / bare object.
+
+    ```javascript
+    const AirbnbStyleGuide = {
+      es6: {
+      }
+    };
+
+    export default AirbnbStyleGuide;
+    ```
+
 
 **[⬆ back to top](#table-of-contents)**
 
 
 ## Accessors
 
-  - Accessor functions for properties are not required
-  - If you do make accessor functions use getVal() and setVal('hello')
+  - [23.1](#23.1) <a name='23.1'></a> Accessor functions for properties are not required.
+  - [23.2](#23.2) <a name='23.2'></a> If you do make accessor functions use getVal() and setVal('hello').
 
     ```javascript
     // bad
@@ -1156,7 +2090,7 @@
     dragon.setAge(25);
     ```
 
-  - If the property is a boolean, use isVal() or hasVal()
+  - [23.3](#23.3) <a name='23.3'></a> If the property is a `boolean`, use `isVal()` or `hasVal()`.
 
     ```javascript
     // bad
@@ -1170,107 +2104,23 @@
     }
     ```
 
-  - It's okay to create get() and set() functions, but be consistent.
+  - [23.4](#23.4) <a name='23.4'></a> It's okay to create get() and set() functions, but be consistent.
 
     ```javascript
-    function Jedi(options) {
-      options || (options = {});
-      var lightsaber = options.lightsaber || 'blue';
-      this.set('lightsaber', lightsaber);
-    }
-
-    Jedi.prototype.set = function(key, val) {
-      this[key] = val;
-    };
-
-    Jedi.prototype.get = function(key) {
-      return this[key];
-    };
-    ```
-
-**[⬆ back to top](#table-of-contents)**
-
-
-## Constructors
-
-  - Assign methods to the prototype object, instead of overwriting the prototype with a new object. Overwriting the prototype makes inheritance impossible: by resetting the prototype you'll overwrite the base!
-
-    ```javascript
-    function Jedi() {
-      console.log('new jedi');
-    }
-
-    // bad
-    Jedi.prototype = {
-      fight: function fight() {
-        console.log('fighting');
-      },
-
-      block: function block() {
-        console.log('blocking');
+    class Jedi {
+      constructor(options = {}) {
+        const lightsaber = options.lightsaber || 'blue';
+        this.set('lightsaber', lightsaber);
       }
-    };
 
-    // good
-    Jedi.prototype.fight = function fight() {
-      console.log('fighting');
-    };
+      set(key, val) {
+        this[key] = val;
+      }
 
-    Jedi.prototype.block = function block() {
-      console.log('blocking');
-    };
-    ```
-
-  - Methods can return `this` to help with method chaining.
-
-    ```javascript
-    // bad
-    Jedi.prototype.jump = function() {
-      this.jumping = true;
-      return true;
-    };
-
-    Jedi.prototype.setHeight = function(height) {
-      this.height = height;
-    };
-
-    var luke = new Jedi();
-    luke.jump(); // => true
-    luke.setHeight(20) // => undefined
-
-    // good
-    Jedi.prototype.jump = function() {
-      this.jumping = true;
-      return this;
-    };
-
-    Jedi.prototype.setHeight = function(height) {
-      this.height = height;
-      return this;
-    };
-
-    var luke = new Jedi();
-
-    luke.jump()
-      .setHeight(20);
-    ```
-
-
-  - It's okay to write a custom toString() method, just make sure it works successfully and causes no side effects.
-
-    ```javascript
-    function Jedi(options) {
-      options || (options = {});
-      this.name = options.name || 'no name';
+      get(key) {
+        return this[key];
+      }
     }
-
-    Jedi.prototype.getName = function getName() {
-      return this.name;
-    };
-
-    Jedi.prototype.toString = function toString() {
-      return 'Jedi - ' + this.getName();
-    };
     ```
 
 **[⬆ back to top](#table-of-contents)**
@@ -1278,28 +2128,28 @@
 
 ## Events
 
-  - When attaching data payloads to events (whether DOM events or something more proprietary like Backbone events), pass a hash instead of a raw value. This allows a subsequent contributor to add more data to the event payload without finding and updating every handler for the event. For example, instead of:
+  - [24.1](#24.1) <a name='24.1'></a> When attaching data payloads to events (whether DOM events or something more proprietary like Backbone events), pass a hash instead of a raw value. This allows a subsequent contributor to add more data to the event payload without finding and updating every handler for the event. For example, instead of:
 
-    ```js
+    ```javascript
     // bad
     $(this).trigger('listingUpdated', listing.id);
 
     ...
 
-    $(this).on('listingUpdated', function(e, listingId) {
+    $(this).on('listingUpdated', function (e, listingId) {
       // do something with listingId
     });
     ```
 
     prefer:
 
-    ```js
+    ```javascript
     // good
-    $(this).trigger('listingUpdated', { listingId : listing.id });
+    $(this).trigger('listingUpdated', { listingId: listing.id });
 
     ...
 
-    $(this).on('listingUpdated', function(e, data) {
+    $(this).on('listingUpdated', function (e, data) {
       // do something with data.listingId
     });
     ```
@@ -1320,50 +2170,22 @@
   **[⬆ back to top](#table-of-contents)**
 
 
-## Modules
-
-  - The module should start with a `!`. This ensures that if a malformed module forgets to include a final semicolon there aren't errors in production when the scripts get concatenated. [Explanation](https://github.com/airbnb/javascript/issues/44#issuecomment-13063933)
-  - The file should be named with camelCase, live in a folder with the same name, and match the name of the single export.
-  - Add a method called noConflict() that sets the exported module to the previous version and returns this one.
-  - Always declare `'use strict';` at the top of the module.
-
-    ```javascript
-    // fancyInput/fancyInput.js
-
-    !function(global) {
-      'use strict';
-
-      var previousFancyInput = global.FancyInput;
-
-      function FancyInput(options) {
-        this.options = options || {};
-      }
-
-      FancyInput.noConflict = function noConflict() {
-        global.FancyInput = previousFancyInput;
-        return FancyInput;
-      };
-
-      global.FancyInput = FancyInput;
-    }(this);
-    ```
-
-**[⬆ back to top](#table-of-contents)**
-
-
 ## jQuery
 
-  - Prefix jQuery object variables with a `$`.
+  - [25.1](#25.1) <a name='25.1'></a> Prefix jQuery object variables with a `$`.
 
     ```javascript
     // bad
-    var sidebar = $('.sidebar');
+    const sidebar = $('.sidebar');
 
     // good
-    var $sidebar = $('.sidebar');
+    const $sidebar = $('.sidebar');
+
+    // good
+    const $sidebarBtn = $('.sidebar-btn');
     ```
 
-  - Cache jQuery lookups.
+  - [25.2](#25.2) <a name='25.2'></a> Cache jQuery lookups.
 
     ```javascript
     // bad
@@ -1379,7 +2201,7 @@
 
     // good
     function setSidebar() {
-      var $sidebar = $('.sidebar');
+      const $sidebar = $('.sidebar');
       $sidebar.hide();
 
       // ...stuff...
@@ -1390,8 +2212,8 @@
     }
     ```
 
-  - For DOM queries use Cascading `$('.sidebar ul')` or parent > child `$('.sidebar > ul')`. [jsPerf](http://jsperf.com/jquery-find-vs-context-sel/16)
-  - Use `find` with scoped jQuery object queries.
+  - [25.3](#25.3) <a name='25.3'></a> For DOM queries use Cascading `$('.sidebar ul')` or parent > child `$('.sidebar > ul')`. [jsPerf](http://jsperf.com/jquery-find-vs-context-sel/16)
+  - [25.4](#25.4) <a name='25.4'></a> Use `find` with scoped jQuery object queries.
 
     ```javascript
     // bad
@@ -1415,27 +2237,54 @@
 
 ## ECMAScript 5 Compatibility
 
-  - The ecmascript5 shim is available. Prefer ES5 methods when it makes sense..
+  - [26.1](#26.1) <a name='26.1'></a> Refer to [Kangax](https://twitter.com/kangax/)'s ES5 [compatibility table](http://kangax.github.io/es5-compat-table/).
 
 **[⬆ back to top](#table-of-contents)**
 
+## ECMAScript 6 Styles
+
+  - [27.1](#27.1) <a name='27.1'></a> This is a collection of links to the various es6 features.
+
+1. [Arrow Functions](#arrow-functions)
+1. [Classes](#constructors)
+1. [Object Shorthand](#es6-object-shorthand)
+1. [Object Concise](#es6-object-concise)
+1. [Object Computed Properties](#es6-computed-properties)
+1. [Template Strings](#es6-template-literals)
+1. [Destructuring](#destructuring)
+1. [Default Parameters](#es6-default-parameters)
+1. [Rest](#es6-rest)
+1. [Array Spreads](#es6-array-spreads)
+1. [Let and Const](#references)
+1. [Iterators and Generators](#iterators-and-generators)
+1. [Modules](#modules)
+
+**[⬆ back to top](#table-of-contents)**
 
 ## Testing
 
-  - **Yup.**
+  - [28.1](#28.1) <a name="28.1"></a> **Yup, all new code should have tests.**,
 
     ```javascript
-    function() {
+    function () {
       return true;
     }
     ```
+
+  - [28.2](#28.2) <a name="28.2"></a> **No, but seriously** we will be working our way towards enforcing this:
+   - Whichever testing framework you use, you should be writing tests!
+   - Strive to write many small pure functions, and minimize where mutations occur.
+   - Be cautious about stubs and mocks - they can make your tests more brittle.
+   - We primarily use [`mocha`](https://www.npmjs.com/package/mocha)at reddit. 
+   - 100% test coverage is a good goal to strive for, even if it's not always practical to reach it.
+   - Whenever you fix a bug, _write a regression test_. A bug fixed without a regression test is almost certainly going to break again in the future.
 
 **[⬆ back to top](#table-of-contents)**
 
 
 ## Performance
 
-  - [On Layout & Web Performance](http://kellegous.com/j/2013/01/26/layout-performance/)
+  - [On Layout & Web Performance](http://www.kellegous.com/j/2013/01/26/layout-performance/)
   - [String vs Array Concat](http://jsperf.com/string-vs-array-concat/2)
   - [Try/Catch Cost In a Loop](http://jsperf.com/try-catch-in-loop-cost)
   - [Bang Function](http://jsperf.com/bang-function)
@@ -1449,23 +2298,36 @@
 
 ## Resources
 
+**Learning ES6**
+
+  - [Draft ECMA 2015 (ES6) Spec](https://people.mozilla.org/~jorendorff/es6-draft.html)
+  - [ExploringJS](http://exploringjs.com/)
+  - [ES6 Compatibility Table](https://kangax.github.io/compat-table/es6/)
+  - [Comprehensive Overview of ES6 Features](http://es6-features.org/)
 
 **Read This**
 
-  - [Annotated ECMAScript 5.1](http://es5.github.com/)
+  - [Standard ECMA-262](http://www.ecma-international.org/ecma-262/6.0/index.html)
 
-**Other Styleguides**
+**Tools**
 
-  - This was adapted from the [Airbnb Javascript Style Guide](https://github.com/airbnb/javascript)
+  - Code Style Linters
+    + [ESlint](http://eslint.org/) - [Airbnb Style .eslintrc](https://github.com/airbnb/javascript/blob/master/linters/.eslintrc)
+    + [JSHint](http://jshint.com/) - [Airbnb Style .jshintrc](https://github.com/airbnb/javascript/blob/master/linters/.jshintrc)
+    + [JSCS](https://github.com/jscs-dev/node-jscs) - [Airbnb Style Preset](https://github.com/jscs-dev/node-jscs/blob/master/presets/airbnb.json)
+
+**Other Style Guides**
+
   - [Google JavaScript Style Guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
-  - [jQuery Core Style Guidelines](http://docs.jquery.com/JQuery_Core_Style_Guidelines)
-  - [Principles of Writing Consistent, Idiomatic JavaScript](https://github.com/rwldrn/idiomatic.js/)
+  - [jQuery Core Style Guidelines](http://contribute.jquery.org/style-guide/js/)
+  - [Principles of Writing Consistent, Idiomatic JavaScript](https://github.com/rwaldron/idiomatic.js)
 
 **Other Styles**
 
-  - [Naming this in nested functions](https://gist.github.com/4135065) - Christian Johansen
-  - [Conditional Callbacks](https://github.com/airbnb/javascript/issues/52)
-  - [Popular JavaScript Coding Conventions on Github](http://sideeffect.kr/popularconvention/#javascript)
+  - [Naming this in nested functions](https://gist.github.com/cjohansen/4135065) - Christian Johansen
+  - [Conditional Callbacks](https://github.com/airbnb/javascript/issues/52) - Ross Allen
+  - [Popular JavaScript Coding Conventions on Github](http://sideeffect.kr/popularconvention/#javascript) - JeongHoon Byun
+  - [Multiple var statements in JavaScript, not superfluous](http://benalman.com/news/2012/05/multiple-var-statements-javascript/) - Ben Alman
 
 **Further Reading**
 
@@ -1473,6 +2335,7 @@
   - [Basic JavaScript for the impatient programmer](http://www.2ality.com/2013/06/basic-javascript.html) - Dr. Axel Rauschmayer
   - [You Might Not Need jQuery](http://youmightnotneedjquery.com/) - Zack Bloom & Adam Schwartz
   - [ES6 Features](https://github.com/lukehoban/es6features) - Luke Hoban
+  - [Frontend Guidelines](https://github.com/bendc/frontend-guidelines) - Benjamin De Cock
 
 **Books**
 
@@ -1487,22 +2350,30 @@
   - [Secrets of the JavaScript Ninja](http://www.amazon.com/Secrets-JavaScript-Ninja-John-Resig/dp/193398869X) - John Resig and Bear Bibeault
   - [Human JavaScript](http://humanjavascript.com/) - Henrik Joreteg
   - [Superhero.js](http://superherojs.com/) - Kim Joar Bekkelund, Mads Mobæk, & Olav Bjorkoy
-  - [JSBooks](http://jsbooks.revolunet.com/)
-  - [Third Party JavaScript](http://manning.com/vinegar/) - Ben Vinegar and Anton Kovalyov
+  - [JSBooks](http://jsbooks.revolunet.com/) - Julien Bouquillon
+  - [Third Party JavaScript](https://www.manning.com/books/third-party-javascript) - Ben Vinegar and Anton Kovalyov
+  - [Effective JavaScript: 68 Specific Ways to Harness the Power of JavaScript](http://amzn.com/0321812182) - David Herman
+  - [Eloquent JavaScript](http://eloquentjavascript.net/) - Marijn Haverbeke
+  - [You Don't Know JS: ES6 & Beyond](http://shop.oreilly.com/product/0636920033769.do) - Kyle Simpson
 
 **Blogs**
 
   - [DailyJS](http://dailyjs.com/)
   - [JavaScript Weekly](http://javascriptweekly.com/)
   - [JavaScript, JavaScript...](http://javascriptweblog.wordpress.com/)
-  - [Bocoup Weblog](http://weblog.bocoup.com/)
+  - [Bocoup Weblog](https://bocoup.com/weblog)
   - [Adequately Good](http://www.adequatelygood.com/)
-  - [NCZOnline](http://www.nczonline.net/)
+  - [NCZOnline](https://www.nczonline.net/)
   - [Perfection Kills](http://perfectionkills.com/)
   - [Ben Alman](http://benalman.com/)
   - [Dmitry Baranovskiy](http://dmitry.baranovskiy.com/)
   - [Dustin Diaz](http://dustindiaz.com/)
-  - [nettuts](http://net.tutsplus.com/?s=javascript)
+  - [nettuts](http://code.tutsplus.com/?s=javascript)
+
+**Podcasts**
+
+  - [JavaScript Jabber](https://devchat.tv/js-jabber/)
+
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -1532,5 +2403,9 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 **[⬆ back to top](#table-of-contents)**
+
+## Amendments
+
+We encourage you to fork this guide and change the rules to fit your team's style guide. Below, you may list some amendments to the style guide. This allows you to periodically update your style guide without having to deal with merge conflicts.
 
 # };

--- a/javascript/es5/README.md
+++ b/javascript/es5/README.md
@@ -1,0 +1,1536 @@
+# reddit JavaScript Style Guide() {
+
+*A mostly reasonable approach to JavaScript*
+
+## Table of Contents
+
+  1. [Types](#types)
+  1. [Objects](#objects)
+  1. [Arrays](#arrays)
+  1. [Strings](#strings)
+  1. [Functions](#functions)
+  1. [Properties](#properties)
+  1. [Variables](#variables)
+  1. [Hoisting](#hoisting)
+  1. [Conditional Expressions & Equality](#conditional-expressions--equality)
+  1. [Blocks](#blocks)
+  1. [Comments](#comments)
+  1. [Whitespace](#whitespace)
+  1. [Commas](#commas)
+  1. [Semicolons](#semicolons)
+  1. [Type Casting & Coercion](#type-casting--coercion)
+  1. [Naming Conventions](#naming-conventions)
+  1. [Accessors](#accessors)
+  1. [Constructors](#constructors)
+  1. [Events](#events)
+  1. [Modules](#modules)
+  1. [jQuery](#jquery)
+  1. [ECMAScript 5 Compatibility](#ecmascript-5-compatibility)
+  1. [Testing](#testing)
+  1. [Performance](#performance)
+  1. [Resources](#resources)
+  1. [License](#license)
+
+## Types
+
+  - **Primitives**: When you access a primitive type you work directly on its value
+
+    + `string`
+    + `number`
+    + `boolean`
+    + `null`
+    + `undefined`
+
+    ```javascript
+    var foo = 1;
+    var bar = foo;
+
+    bar = 9;
+
+    console.log(foo, bar); // => 1, 9
+    ```
+  - **Complex**: When you access a complex type you work on a reference to its value
+
+    + `object`
+    + `array`
+    + `function`
+
+    ```javascript
+    var foo = [1, 2];
+    var bar = foo;
+
+    bar[0] = 9;
+
+    console.log(foo[0], bar[0]); // => 9, 9
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+## Objects
+
+  - Use the literal syntax for object creation.
+
+    ```javascript
+    // bad
+    var item = new Object();
+
+    // good
+    var item = {};
+    ```
+
+  - Don't use [reserved words](http://es5.github.io/#x7.6.1) as keys. It won't work in IE8. [More info](https://github.com/airbnb/javascript/issues/61)
+
+    ```javascript
+    // bad
+    var superman = {
+      default: { clark: 'kent' },
+      private: true
+    };
+
+    // good
+    var superman = {
+      defaults: { clark: 'kent' },
+      hidden: true
+    };
+    ```
+
+  - Use readable synonyms in place of reserved words.
+
+    ```javascript
+    // bad
+    var superman = {
+      class: 'alien'
+    };
+
+    // bad
+    var superman = {
+      klass: 'alien'
+    };
+
+    // good
+    var superman = {
+      type: 'alien'
+    };
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+## Arrays
+
+  - Use the literal syntax for array creation
+
+    ```javascript
+    // bad
+    var items = new Array();
+
+    // good
+    var items = [];
+    ```
+
+  - If you don't know array length use Array#push.
+
+    ```javascript
+    var someStack = [];
+
+
+    // bad
+    someStack[someStack.length] = 'abracadabra';
+
+    // good
+    someStack.push('abracadabra');
+    ```
+
+  - When you need to copy an array use Array#slice. [jsPerf](http://jsperf.com/converting-arguments-to-an-array/7)
+
+    ```javascript
+    var len = items.length;
+    var itemsCopy = [];
+    var i;
+
+    // bad
+    for (i = 0; i < len; i++) {
+      itemsCopy[i] = items[i];
+    }
+
+    // good
+    itemsCopy = items.slice();
+    ```
+
+  - To convert an array-like object to an array, use Array#slice.
+
+    ```javascript
+    function trigger() {
+      var args = Array.prototype.slice.call(arguments);
+      ...
+    }
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Strings
+
+  - Use single quotes `''` for strings
+
+    ```javascript
+    // bad
+    var name = "Bob Parr";
+
+    // good
+    var name = 'Bob Parr';
+
+    // bad
+    var fullName = "Bob " + this.lastName;
+
+    // good
+    var fullName = 'Bob ' + this.lastName;
+    ```
+
+  - Strings longer than 80 characters should be written across multiple lines using string concatenation.
+  - Note: If overused, long strings with concatenation could impact performance. [jsPerf](http://jsperf.com/ya-string-concat) & [Discussion](https://github.com/airbnb/javascript/issues/40)
+
+    ```javascript
+    // bad
+    var errorMessage = 'This is a super long error that was thrown because of Batman. When you stop to think about how Batman had anything to do with this, you would get nowhere fast.';
+
+    // bad
+    var errorMessage = 'This is a super long error that was thrown because \
+    of Batman. When you stop to think about how Batman had anything to do \
+    with this, you would get nowhere \
+    fast.';
+
+    // good
+    var errorMessage = 'This is a super long error that was thrown because ' +
+      'of Batman. When you stop to think about how Batman had anything to do ' +
+      'with this, you would get nowhere fast.';
+    ```
+
+  - When programmatically building up a string, use Array#join instead of string concatenation. Mostly for IE: [jsPerf](http://jsperf.com/string-vs-array-concat/2).
+
+    ```javascript
+    var items;
+    var messages;
+    var length;
+    var i;
+
+    messages = [{
+      state: 'success',
+      message: 'This one worked.'
+    }, {
+      state: 'success',
+      message: 'This one worked as well.'
+    }, {
+      state: 'error',
+      message: 'This one did not work.'
+    }];
+
+    length = messages.length;
+
+    // bad
+    function inbox(messages) {
+      items = '<ul>';
+
+      for (i = 0; i < length; i++) {
+        items += '<li>' + messages[i].message + '</li>';
+      }
+
+      return items + '</ul>';
+    }
+
+    // good
+    function inbox(messages) {
+      items = [];
+
+      for (i = 0; i < length; i++) {
+        items[i] = messages[i].message;
+      }
+
+      return '<ul><li>' + items.join('</li><li>') + '</li></ul>';
+    }
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Functions
+
+  - Function expressions:
+
+    ```javascript
+    // anonymous function expression
+    var anonymous = function() {
+      return true;
+    };
+
+    // named function expression
+    var named = function named() {
+      return true;
+    };
+
+    // immediately-invoked function expression (IIFE)
+    (function() {
+      console.log('Welcome to the Internet. Please follow me.');
+    })();
+    ```
+
+  - Never declare a function in a non-function block (if, while, etc). Assign the function to a variable instead. Browsers will allow you to do it, but they all interpret it differently, which is bad news bears.
+  - **Note:** ECMA-262 defines a `block` as a list of statements. A function declaration is not a statement. [Read ECMA-262's note on this issue](http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf#page=97).
+
+    ```javascript
+    // bad
+    if (currentUser) {
+      function test() {
+        console.log('Nope.');
+      }
+    }
+
+    // good
+    var test;
+    if (currentUser) {
+      test = function test() {
+        console.log('Yup.');
+      };
+    }
+    ```
+
+  - Never name a parameter `arguments`, this will take precedence over the `arguments` object that is given to every function scope.
+
+    ```javascript
+    // bad
+    function nope(name, options, arguments) {
+      // ...stuff...
+    }
+
+    // good
+    function yup(name, options, args) {
+      // ...stuff...
+    }
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+
+## Properties
+
+  - Use dot notation when accessing properties.
+
+    ```javascript
+    var luke = {
+      jedi: true,
+      age: 28
+    };
+
+    // bad
+    var isJedi = luke['jedi'];
+
+    // good
+    var isJedi = luke.jedi;
+    ```
+
+  - Use subscript notation `[]` when accessing properties with a variable.
+
+    ```javascript
+    var luke = {
+      jedi: true,
+      age: 28
+    };
+
+    function getProp(prop) {
+      return luke[prop];
+    }
+
+    var isJedi = getProp('jedi');
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Variables
+
+  - Always use `var` to declare variables. Not doing so will result in global variables. We want to avoid polluting the global namespace. Captain Planet warned us of that.
+
+    ```javascript
+    // bad
+    superPower = new SuperPower();
+
+    // good
+    var superPower = new SuperPower();
+    ```
+
+  - Use multiple `var` declarations for multiple variables and declare each variable on a newline.
+
+    ```javascript
+    // bad
+    var items = getItems(),
+        goSportsTeam = true,
+        dragonball = 'z';
+
+    // good
+    var items = getItems();
+    var goSportsTeam = true;
+    var dragonball = 'z';
+    ```
+
+  - Declare unassigned variables last. This is helpful when later on you might need to assign a variable depending on one of the previous assigned variables.
+
+    ```javascript
+    // bad
+    var i, len, dragonball,
+        items = getItems(),
+        goSportsTeam = true;
+
+    // bad
+    var i, items = getItems(),
+        dragonball,
+        goSportsTeam = true,
+        len;
+
+    // good
+    var items = getItems();
+    var goSportsTeam = true;
+    var dragonball;
+    var length;
+    var i;
+    ```
+
+  - Assign variables at the top of their scope. This helps avoid issues with variable declaration and assignment hoisting related issues.
+
+    ```javascript
+    // bad
+    function() {
+      test();
+      console.log('doing stuff..');
+
+      //..other stuff..
+
+      var name = getName();
+
+      if (name === 'test') {
+        return false;
+      }
+
+      return name;
+    }
+
+    // good
+    function() {
+      var name = getName();
+
+      test();
+      console.log('doing stuff..');
+
+      //..other stuff..
+
+      if (name === 'test') {
+        return false;
+      }
+
+      return name;
+    }
+
+    // bad
+    function() {
+      var name = getName();
+
+      if (!arguments.length) {
+        return false;
+      }
+
+      return true;
+    }
+
+    // good
+    function() {
+      if (!arguments.length) {
+        return false;
+      }
+
+      var name = getName();
+
+      return true;
+    }
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Hoisting
+
+  - Variable declarations get hoisted to the top of their scope, their assignment does not.
+
+    ```javascript
+    // we know this wouldn't work (assuming there
+    // is no notDefined global variable)
+    function example() {
+      console.log(notDefined); // => throws a ReferenceError
+    }
+
+    // creating a variable declaration after you
+    // reference the variable will work due to
+    // variable hoisting. Note: the assignment
+    // value of `true` is not hoisted.
+    function example() {
+      console.log(declaredButNotAssigned); // => undefined
+      var declaredButNotAssigned = true;
+    }
+
+    // The interpreter is hoisting the variable
+    // declaration to the top of the scope.
+    // Which means our example could be rewritten as:
+    function example() {
+      var declaredButNotAssigned;
+      console.log(declaredButNotAssigned); // => undefined
+      declaredButNotAssigned = true;
+    }
+    ```
+
+  - Anonymous function expressions hoist their variable name, but not the function assignment.
+
+    ```javascript
+    function example() {
+      console.log(anonymous); // => undefined
+
+      anonymous(); // => TypeError anonymous is not a function
+
+      var anonymous = function() {
+        console.log('anonymous function expression');
+      };
+    }
+    ```
+
+  - Named function expressions hoist the variable name, not the function name or the function body.
+
+    ```javascript
+    function example() {
+      console.log(named); // => undefined
+
+      named(); // => TypeError named is not a function
+
+      superPower(); // => ReferenceError superPower is not defined
+
+      var named = function superPower() {
+        console.log('Flying');
+      };
+    }
+
+    // the same is true when the function name
+    // is the same as the variable name.
+    function example() {
+      console.log(named); // => undefined
+
+      named(); // => TypeError named is not a function
+
+      var named = function named() {
+        console.log('named');
+      }
+    }
+    ```
+
+  - Function declarations hoist their name and the function body.
+
+    ```javascript
+    function example() {
+      superPower(); // => Flying
+
+      function superPower() {
+        console.log('Flying');
+      }
+    }
+    ```
+
+  - For more information refer to [JavaScript Scoping & Hoisting](http://www.adequatelygood.com/2010/2/JavaScript-Scoping-and-Hoisting) by [Ben Cherry](http://www.adequatelygood.com/)
+
+**[⬆ back to top](#table-of-contents)**
+
+
+
+## Conditional Expressions & Equality
+
+  - Use `===` and `!==` over `==` and `!=`.
+  - Conditional expressions are evaluated using coercion with the `ToBoolean` method and always follow these simple rules:
+
+    + **Objects** evaluate to **true**
+    + **Undefined** evaluates to **false**
+    + **Null** evaluates to **false**
+    + **Booleans** evaluate to **the value of the boolean**
+    + **Numbers** evaluate to **false** if **+0, -0, or NaN**, otherwise **true**
+    + **Strings** evaluate to **false** if an empty string `''`, otherwise **true**
+
+    ```javascript
+    if ([0]) {
+      // true
+      // An array is an object, objects evaluate to true
+    }
+    ```
+
+  - Use shortcuts.
+
+    ```javascript
+    // bad
+    if (name !== '') {
+      // ...stuff...
+    }
+
+    // good
+    if (name) {
+      // ...stuff...
+    }
+
+    // bad
+    if (collection.length > 0) {
+      // ...stuff...
+    }
+
+    // good
+    if (collection.length) {
+      // ...stuff...
+    }
+    ```
+
+  - For more information see [Truth Equality and JavaScript](http://javascriptweblog.wordpress.com/2011/02/07/truth-equality-and-javascript/#more-2108) by Angus Croll
+
+  - Put your curly braces on the same line for `else` / `else if`s.
+
+    ```javascript
+    //bad
+    if (name === 'jane') {
+      // ...stuff
+    }
+    else if (name === 'bob') {
+      // ...stuff
+    }
+    else {
+      // ...stuff
+    }
+
+    //good
+    if (name === 'jane') {
+      // ...stuff
+    } else if (name === 'bob') {
+      // ...stuff
+    } else {
+      // ...stuff
+    }
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Blocks
+
+  - Use braces. Single-line functions are okay if short. Single-line conditionals are okay if short.
+
+    ```javascript
+    // bad
+    if (test)
+      return false;
+
+    // bad
+    if (test) return false;
+
+    // good
+    if (test) { return false; }
+
+    // good
+    if (test) {
+      return false;
+    }
+
+    // good
+    function() { return false; }
+
+    // good
+    function() {
+      return false;
+    }
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Comments
+
+  - Use `/** ... */` for docstring comments. Include a description, specify types and values for all parameters and return values.
+
+    ```javascript
+    // bad
+    // make() returns a new element
+    // based on the passed in tag name
+    //
+    // @param <String> tag
+    // @return <Element> element
+    function make(tag) {
+
+      // ...stuff...
+
+      return element;
+    }
+
+    // good
+    /**
+     * make() returns a new element
+     * based on the passed in tag name
+     *
+     * @param <String> tag
+     * @return <Element> element
+     */
+    function make(tag) {
+
+      // ...stuff...
+
+      return element;
+    }
+    ```
+
+  - Use `//` for single line comments and multi-line comments that aren't docstrings. Place single line comments on a newline above the subject of the comment. Put an empty line before the comment.
+
+    ```javascript
+    // bad
+    var active = true;  // is current tab
+
+    // good
+    // is current tab
+    var active = true;
+
+    // bad
+    function getType() {
+      console.log('fetching type...');
+      // set the default type to 'no type'
+      var type = this._type || 'no type';
+
+      return type;
+    }
+
+    // good
+    function getType() {
+      console.log('fetching type...');
+
+      // set the default type to 'no type'
+      var type = this._type || 'no type';
+
+      return type;
+    }
+    ```
+
+  - Prefixing your comments with `FIXME` or `TODO` helps other developers quickly understand if you're pointing out a problem that needs to be revisited, or if you're suggesting a solution to the problem that needs to be implemented. These are different than regular comments because they are actionable. The actions are `FIXME -- need to figure this out` or `TODO -- need to implement`.
+
+  - Use `// FIXME:` to annotate problems
+
+    ```javascript
+    function Calculator() {
+
+      // FIXME: shouldn't use a global here
+      total = 0;
+
+      return this;
+    }
+    ```
+
+  - Use `// TODO:` to annotate solutions to problems
+
+    ```javascript
+    function Calculator() {
+
+      // TODO: total should be configurable by an options param
+      this.total = 0;
+
+      return this;
+    }
+  ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Whitespace
+
+  - Use soft tabs set to 2 spaces
+
+    ```javascript
+    // bad
+    function() {
+    ∙∙∙∙var name;
+    }
+
+    // bad
+    function() {
+    ∙var name;
+    }
+
+    // good
+    function() {
+    ∙∙var name;
+    }
+    ```
+
+  - Place 1 space before the leading brace.
+
+    ```javascript
+    // bad
+    function test(){
+      console.log('test');
+    }
+
+    // good
+    function test() {
+      console.log('test');
+    }
+
+    // bad
+    dog.set('attr',{
+      age: '1 year',
+      breed: 'Bernese Mountain Dog'
+    });
+
+    // good
+    dog.set('attr', {
+      age: '1 year',
+      breed: 'Bernese Mountain Dog'
+    });
+    ```
+
+  - Set off operators with spaces.
+
+    ```javascript
+    // bad
+    var x=y+5;
+
+    // good
+    var x = y + 5;
+    ```
+
+  - Files should end with a single newline character.
+
+    ```javascript
+    // good
+    (function(global) {
+      // ...stuff...
+    })(this);↵
+    ```
+
+    ```javascript
+    // bad
+    (function(global) {
+      // ...stuff...
+    })(this);
+    ```
+
+    ```javascript
+    // bad
+    (function(global) {
+      // ...stuff...
+    })(this)↵
+    ↵
+    ```
+
+  - Use indentation when making long method chains.
+
+    ```javascript
+    // bad
+    $('#items').find('.selected').highlight().end().find('.open').updateCount();
+
+    // good
+    $('#items')
+      .find('.selected')
+        .highlight()
+        .end()
+      .find('.open')
+        .updateCount();
+
+    // bad
+    var leds = stage.selectAll('.led').data(data).enter().append('svg:svg').class('led', true)
+        .attr('width',  (radius + margin) * 2).append('svg:g')
+        .attr('transform', 'translate(' + (radius + margin) + ',' + (radius + margin) + ')')
+        .call(tron.led);
+
+    // good
+    var leds = stage.selectAll('.led')
+        .data(data)
+      .enter().append('svg:svg')
+        .class('led', true)
+        .attr('width',  (radius + margin) * 2)
+      .append('svg:g')
+        .attr('transform', 'translate(' + (radius + margin) + ',' + (radius + margin) + ')')
+        .call(tron.led);
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+## Commas
+
+  - Leading commas: **Nope.**
+
+    ```javascript
+    // bad
+    var once
+      , upon
+      , aTime;
+
+    // good
+    var once = [
+      'upon',
+      'a',
+      'time'
+    ]
+
+    // bad
+    var hero = {
+        firstName: 'Bob'
+      , lastName: 'Parr'
+      , heroName: 'Mr. Incredible'
+      , superPower: 'strength'
+    };
+
+    // good
+    var hero = {
+      firstName: 'Bob',
+      lastName: 'Parr',
+      heroName: 'Mr. Incredible',
+      superPower: 'strength'
+    };
+    ```
+
+  - Additional trailing comma: **Yup.** Our Javascript is run through a compiler, and we're not terribly worried about IE < 9 support. This makes diffs cleaner. This was clarified in ES5 ([source](http://es5.github.io/#D)):
+
+  > Edition 5 clarifies the fact that a trailing comma at the end of an ArrayInitialiser does not add to the length of the array. This is not a semantic change from Edition 3 but some implementations may have previously misinterpreted this.
+
+    ```javascript
+    // bad
+    var hero = {
+      firstName: 'Kevin',
+      lastName: 'Flynn'
+    };
+
+    var heroes = [
+      'Batman',
+      'Superman'
+    ];
+
+    // good
+    var hero = {
+      firstName: 'Kevin',
+      lastName: 'Flynn',
+    };
+
+    var heroes = [
+      'Batman',
+      'Superman',
+    ];
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Semicolons
+
+  - **Yup.**
+
+    ```javascript
+    // bad
+    (function() {
+      var name = 'Skywalker'
+      return name
+    })()
+
+    // good
+    (function() {
+      var name = 'Skywalker';
+      return name;
+    })();
+
+    // good
+    ;(function() {
+      var name = 'Skywalker';
+      return name;
+    })();
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Type Casting & Coercion
+
+  - Perform type coercion at the beginning of the statement.
+  - Strings:
+
+    ```javascript
+    //  => this.reviewScore = 9;
+
+    // bad
+    var totalScore = this.reviewScore + '';
+
+    // good
+    var totalScore = '' + this.reviewScore;
+
+    // bad
+    var totalScore = '' + this.reviewScore + ' total score';
+
+    // good
+    var totalScore = this.reviewScore + ' total score';
+    ```
+
+  - Use `parseInt` for Numbers and always with a radix for type casting.
+
+    ```javascript
+    var inputValue = '4';
+
+    // bad
+    var val = new Number(inputValue);
+
+    // bad
+    var val = +inputValue;
+
+    // bad
+    var val = inputValue >> 0;
+
+    // bad
+    var val = parseInt(inputValue);
+
+    // good
+    var val = Number(inputValue);
+
+    // good
+    var val = parseInt(inputValue, 10);
+    ```
+
+  - If for whatever reason you are doing something wild and `parseInt` is your bottleneck and need to use Bitshift for [performance reasons](http://jsperf.com/coercion-vs-casting/3), leave a comment explaining why and what you're doing.
+  - **Note:** Be careful when using bitshift operations. Numbers are represented as [64-bit values](http://es5.github.io/#x4.3.19), but Bitshift operations always return a 32-bit integer ([source](http://es5.github.io/#x11.7)). Bitshift can lead to unexpected behavior for integer values larger than 32 bits. [Discussion](https://github.com/airbnb/javascript/issues/109)
+
+    ```javascript
+    // good
+    /**
+     * parseInt was the reason my code was slow.
+     * Bitshifting the String to coerce it to a
+     * Number made it a lot faster.
+     */
+    var val = inputValue >> 0;
+    ```
+
+  - Booleans:
+
+    ```javascript
+    var age = 0;
+
+    // bad
+    var hasAge = new Boolean(age);
+
+    // good
+    var hasAge = Boolean(age);
+
+    // good
+    var hasAge = !!age;
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Naming Conventions
+
+  - Avoid single letter names. Be descriptive with your naming.
+
+    ```javascript
+    // bad
+    function q() {
+      // ...stuff...
+    }
+
+    // good
+    function query() {
+      // ..stuff..
+    }
+    ```
+
+  - Use camelCase when naming objects, functions, and instances
+
+    ```javascript
+    // bad
+    var OBJEcttsssss = {};
+    var this_is_my_object = {};
+    function c() {};
+    var u = new user({
+      name: 'Bob Parr'
+    });
+
+    // good
+    var thisIsMyObject = {};
+    function thisIsMyFunction() {};
+    var user = new User({
+      name: 'Bob Parr'
+    });
+    ```
+
+  - Use PascalCase when naming constructors or classes
+
+    ```javascript
+    // bad
+    function user(options) {
+      this.name = options.name;
+    }
+
+    var bad = new user({
+      name: 'nope'
+    });
+
+    // good
+    function User(options) {
+      this.name = options.name;
+    }
+
+    var good = new User({
+      name: 'yup'
+    });
+    ```
+
+  - Use a leading underscore `_` when naming private properties
+
+    ```javascript
+    // bad
+    this.__firstName__ = 'Panda';
+    this.firstName_ = 'Panda';
+
+    // good
+    this._firstName = 'Panda';
+    ```
+
+  - When saving a reference to `this` use `_this`.
+
+    ```javascript
+    // bad
+    function() {
+      var self = this;
+      return function() {
+        console.log(self);
+      };
+    }
+
+    // bad
+    function() {
+      var that = this;
+      return function() {
+        console.log(that);
+      };
+    }
+
+    // good
+    function() {
+      var _this = this;
+      return function() {
+        console.log(_this);
+      };
+    }
+    ```
+
+  - Name your functions. This is helpful for stack traces.
+
+    ```javascript
+    // bad
+    var log = function(msg) {
+      console.log(msg);
+    };
+
+    // good
+    var log = function log(msg) {
+      console.log(msg);
+    };
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Accessors
+
+  - Accessor functions for properties are not required
+  - If you do make accessor functions use getVal() and setVal('hello')
+
+    ```javascript
+    // bad
+    dragon.age();
+
+    // good
+    dragon.getAge();
+
+    // bad
+    dragon.age(25);
+
+    // good
+    dragon.setAge(25);
+    ```
+
+  - If the property is a boolean, use isVal() or hasVal()
+
+    ```javascript
+    // bad
+    if (!dragon.age()) {
+      return false;
+    }
+
+    // good
+    if (!dragon.hasAge()) {
+      return false;
+    }
+    ```
+
+  - It's okay to create get() and set() functions, but be consistent.
+
+    ```javascript
+    function Jedi(options) {
+      options || (options = {});
+      var lightsaber = options.lightsaber || 'blue';
+      this.set('lightsaber', lightsaber);
+    }
+
+    Jedi.prototype.set = function(key, val) {
+      this[key] = val;
+    };
+
+    Jedi.prototype.get = function(key) {
+      return this[key];
+    };
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Constructors
+
+  - Assign methods to the prototype object, instead of overwriting the prototype with a new object. Overwriting the prototype makes inheritance impossible: by resetting the prototype you'll overwrite the base!
+
+    ```javascript
+    function Jedi() {
+      console.log('new jedi');
+    }
+
+    // bad
+    Jedi.prototype = {
+      fight: function fight() {
+        console.log('fighting');
+      },
+
+      block: function block() {
+        console.log('blocking');
+      }
+    };
+
+    // good
+    Jedi.prototype.fight = function fight() {
+      console.log('fighting');
+    };
+
+    Jedi.prototype.block = function block() {
+      console.log('blocking');
+    };
+    ```
+
+  - Methods can return `this` to help with method chaining.
+
+    ```javascript
+    // bad
+    Jedi.prototype.jump = function() {
+      this.jumping = true;
+      return true;
+    };
+
+    Jedi.prototype.setHeight = function(height) {
+      this.height = height;
+    };
+
+    var luke = new Jedi();
+    luke.jump(); // => true
+    luke.setHeight(20) // => undefined
+
+    // good
+    Jedi.prototype.jump = function() {
+      this.jumping = true;
+      return this;
+    };
+
+    Jedi.prototype.setHeight = function(height) {
+      this.height = height;
+      return this;
+    };
+
+    var luke = new Jedi();
+
+    luke.jump()
+      .setHeight(20);
+    ```
+
+
+  - It's okay to write a custom toString() method, just make sure it works successfully and causes no side effects.
+
+    ```javascript
+    function Jedi(options) {
+      options || (options = {});
+      this.name = options.name || 'no name';
+    }
+
+    Jedi.prototype.getName = function getName() {
+      return this.name;
+    };
+
+    Jedi.prototype.toString = function toString() {
+      return 'Jedi - ' + this.getName();
+    };
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Events
+
+  - When attaching data payloads to events (whether DOM events or something more proprietary like Backbone events), pass a hash instead of a raw value. This allows a subsequent contributor to add more data to the event payload without finding and updating every handler for the event. For example, instead of:
+
+    ```js
+    // bad
+    $(this).trigger('listingUpdated', listing.id);
+
+    ...
+
+    $(this).on('listingUpdated', function(e, listingId) {
+      // do something with listingId
+    });
+    ```
+
+    prefer:
+
+    ```js
+    // good
+    $(this).trigger('listingUpdated', { listingId : listing.id });
+
+    ...
+
+    $(this).on('listingUpdated', function(e, data) {
+      // do something with data.listingId
+    });
+    ```
+
+  - For event handlers, prefix with "on" and use the present tense. Prefer "on" + eventName, but if ambiguous other words may be used.
+
+    ```js
+    // bad
+    this.listenTo(this.model, 'add', this.added)
+
+    // good
+    this.listenTo(this.model, 'add', this.onAdd)
+
+    // also good
+    this.listenTo(this.model, 'add', this.onAddItem)
+    ```
+
+  **[⬆ back to top](#table-of-contents)**
+
+
+## Modules
+
+  - The module should start with a `!`. This ensures that if a malformed module forgets to include a final semicolon there aren't errors in production when the scripts get concatenated. [Explanation](https://github.com/airbnb/javascript/issues/44#issuecomment-13063933)
+  - The file should be named with camelCase, live in a folder with the same name, and match the name of the single export.
+  - Add a method called noConflict() that sets the exported module to the previous version and returns this one.
+  - Always declare `'use strict';` at the top of the module.
+
+    ```javascript
+    // fancyInput/fancyInput.js
+
+    !function(global) {
+      'use strict';
+
+      var previousFancyInput = global.FancyInput;
+
+      function FancyInput(options) {
+        this.options = options || {};
+      }
+
+      FancyInput.noConflict = function noConflict() {
+        global.FancyInput = previousFancyInput;
+        return FancyInput;
+      };
+
+      global.FancyInput = FancyInput;
+    }(this);
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## jQuery
+
+  - Prefix jQuery object variables with a `$`.
+
+    ```javascript
+    // bad
+    var sidebar = $('.sidebar');
+
+    // good
+    var $sidebar = $('.sidebar');
+    ```
+
+  - Cache jQuery lookups.
+
+    ```javascript
+    // bad
+    function setSidebar() {
+      $('.sidebar').hide();
+
+      // ...stuff...
+
+      $('.sidebar').css({
+        'background-color': 'pink'
+      });
+    }
+
+    // good
+    function setSidebar() {
+      var $sidebar = $('.sidebar');
+      $sidebar.hide();
+
+      // ...stuff...
+
+      $sidebar.css({
+        'background-color': 'pink'
+      });
+    }
+    ```
+
+  - For DOM queries use Cascading `$('.sidebar ul')` or parent > child `$('.sidebar > ul')`. [jsPerf](http://jsperf.com/jquery-find-vs-context-sel/16)
+  - Use `find` with scoped jQuery object queries.
+
+    ```javascript
+    // bad
+    $('ul', '.sidebar').hide();
+
+    // bad
+    $('.sidebar').find('ul').hide();
+
+    // good
+    $('.sidebar ul').hide();
+
+    // good
+    $('.sidebar > ul').hide();
+
+    // good
+    $sidebar.find('ul').hide();
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## ECMAScript 5 Compatibility
+
+  - The ecmascript5 shim is available. Prefer ES5 methods when it makes sense..
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Testing
+
+  - **Yup.**
+
+    ```javascript
+    function() {
+      return true;
+    }
+    ```
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Performance
+
+  - [On Layout & Web Performance](http://kellegous.com/j/2013/01/26/layout-performance/)
+  - [String vs Array Concat](http://jsperf.com/string-vs-array-concat/2)
+  - [Try/Catch Cost In a Loop](http://jsperf.com/try-catch-in-loop-cost)
+  - [Bang Function](http://jsperf.com/bang-function)
+  - [jQuery Find vs Context, Selector](http://jsperf.com/jquery-find-vs-context-sel/13)
+  - [innerHTML vs textContent for script text](http://jsperf.com/innerhtml-vs-textcontent-for-script-text)
+  - [Long String Concatenation](http://jsperf.com/ya-string-concat)
+  - Loading...
+
+**[⬆ back to top](#table-of-contents)**
+
+
+## Resources
+
+
+**Read This**
+
+  - [Annotated ECMAScript 5.1](http://es5.github.com/)
+
+**Other Styleguides**
+
+  - This was adapted from the [Airbnb Javascript Style Guide](https://github.com/airbnb/javascript)
+  - [Google JavaScript Style Guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+  - [jQuery Core Style Guidelines](http://docs.jquery.com/JQuery_Core_Style_Guidelines)
+  - [Principles of Writing Consistent, Idiomatic JavaScript](https://github.com/rwldrn/idiomatic.js/)
+
+**Other Styles**
+
+  - [Naming this in nested functions](https://gist.github.com/4135065) - Christian Johansen
+  - [Conditional Callbacks](https://github.com/airbnb/javascript/issues/52)
+  - [Popular JavaScript Coding Conventions on Github](http://sideeffect.kr/popularconvention/#javascript)
+
+**Further Reading**
+
+  - [Understanding JavaScript Closures](http://javascriptweblog.wordpress.com/2010/10/25/understanding-javascript-closures/) - Angus Croll
+  - [Basic JavaScript for the impatient programmer](http://www.2ality.com/2013/06/basic-javascript.html) - Dr. Axel Rauschmayer
+  - [You Might Not Need jQuery](http://youmightnotneedjquery.com/) - Zack Bloom & Adam Schwartz
+  - [ES6 Features](https://github.com/lukehoban/es6features) - Luke Hoban
+
+**Books**
+
+  - [JavaScript: The Good Parts](http://www.amazon.com/JavaScript-Good-Parts-Douglas-Crockford/dp/0596517742) - Douglas Crockford
+  - [JavaScript Patterns](http://www.amazon.com/JavaScript-Patterns-Stoyan-Stefanov/dp/0596806752) - Stoyan Stefanov
+  - [Pro JavaScript Design Patterns](http://www.amazon.com/JavaScript-Design-Patterns-Recipes-Problem-Solution/dp/159059908X)  - Ross Harmes and Dustin Diaz
+  - [High Performance Web Sites: Essential Knowledge for Front-End Engineers](http://www.amazon.com/High-Performance-Web-Sites-Essential/dp/0596529309) - Steve Souders
+  - [Maintainable JavaScript](http://www.amazon.com/Maintainable-JavaScript-Nicholas-C-Zakas/dp/1449327680) - Nicholas C. Zakas
+  - [JavaScript Web Applications](http://www.amazon.com/JavaScript-Web-Applications-Alex-MacCaw/dp/144930351X) - Alex MacCaw
+  - [Pro JavaScript Techniques](http://www.amazon.com/Pro-JavaScript-Techniques-John-Resig/dp/1590597273) - John Resig
+  - [Smashing Node.js: JavaScript Everywhere](http://www.amazon.com/Smashing-Node-js-JavaScript-Everywhere-Magazine/dp/1119962595) - Guillermo Rauch
+  - [Secrets of the JavaScript Ninja](http://www.amazon.com/Secrets-JavaScript-Ninja-John-Resig/dp/193398869X) - John Resig and Bear Bibeault
+  - [Human JavaScript](http://humanjavascript.com/) - Henrik Joreteg
+  - [Superhero.js](http://superherojs.com/) - Kim Joar Bekkelund, Mads Mobæk, & Olav Bjorkoy
+  - [JSBooks](http://jsbooks.revolunet.com/)
+  - [Third Party JavaScript](http://manning.com/vinegar/) - Ben Vinegar and Anton Kovalyov
+
+**Blogs**
+
+  - [DailyJS](http://dailyjs.com/)
+  - [JavaScript Weekly](http://javascriptweekly.com/)
+  - [JavaScript, JavaScript...](http://javascriptweblog.wordpress.com/)
+  - [Bocoup Weblog](http://weblog.bocoup.com/)
+  - [Adequately Good](http://www.adequatelygood.com/)
+  - [NCZOnline](http://www.nczonline.net/)
+  - [Perfection Kills](http://perfectionkills.com/)
+  - [Ben Alman](http://benalman.com/)
+  - [Dmitry Baranovskiy](http://dmitry.baranovskiy.com/)
+  - [Dustin Diaz](http://dustindiaz.com/)
+  - [nettuts](http://net.tutsplus.com/?s=javascript)
+
+**[⬆ back to top](#table-of-contents)**
+
+## License
+
+(The MIT License)
+
+Copyright (c) 2014 Airbnb
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+**[⬆ back to top](#table-of-contents)**
+
+# };

--- a/javascript/linters/eslintrc
+++ b/javascript/linters/eslintrc
@@ -1,0 +1,70 @@
+{
+  "parser": "babel-eslint",
+
+  "root": true,
+
+  "env": {
+    // I write for browser
+    "browser": true,
+    // in CommonJS
+    "node": true
+  },
+
+  "extends": "eslint:recommended",
+
+  // plugins let use use custom rules below
+  "plugins": [
+    "babel",
+    "react"
+  ],
+
+  "ecmaFeatures": {
+      "jsx": true,
+      "es6": true,
+    },
+
+  "rules": {
+    // 0 = off
+    // 1 = warn
+    // 2 = error
+
+    // React specifc rules
+    "react/jsx-boolean-value": 0,
+    "react/jsx-closing-bracket-location": 1,
+    "react/jsx-curly-spacing": [2, "always"],
+    "react/jsx-indent-props": [1, 2],
+    "react/jsx-no-undef": 1,
+    "react/jsx-uses-react": 1,
+    "react/jsx-uses-vars": 1,
+    "react/wrap-multilines": 1,
+    "react/react-in-jsx-scope": 1,
+    "react/prefer-es6-class": 1,
+    // no binding functions in render for perf
+    "react/jsx-no-bind": 1,
+
+    // handle async/await functions correctly
+    // "babel/generator-star-spacing": 1,
+    // handle object spread
+    "babel/object-shorthand": 1,
+
+    "indent": [2, 2, {"SwitchCase": 1}],
+    "max-len": [1, 100, 2, {"ignoreComments": true}],
+    "no-unused-vars": 1,
+    "no-console": 0,
+    // semicolons
+    "semi": [2, "always"],
+    "brace-style": [2, "1tbs", { "allowSingleLine": true }],
+    "comma-dangle": [2, "always-multiline"],
+    "consistent-return": 0,
+    "no-underscore-dangle": 0,
+    "quotes": [2, "single"],
+    "space-after-keywords": [2, "always"],
+    "space-before-blocks": [2, "always"],
+    "space-before-function-parentheses": [0, "never"],
+    "space-in-brackets": [0, "never"],
+    "space-in-parens": [2, "never"],
+    "space-return-throw-case": 1,
+    "space-unary-ops": [1, { "words": true, "nonwords": false }],
+    "strict": [2, "never"],
+  }
+}

--- a/javascript/react/README.md
+++ b/javascript/react/README.md
@@ -1,0 +1,310 @@
+# reddit React/JSX Style Guide
+
+*A mostly reasonable approach to React and JSX*
+
+## Table of Contents
+
+  1. [Basic Rules](#basic-rules)
+  1. [Class vs `React.createClass`](#class-vs-reactcreateclass)
+  1. [Naming](#naming)
+  1. [Declaration](#declaration)
+  1. [Alignment](#alignment)
+  1. [Spacing](#spacing)
+  1. [Props](#props)
+  1. [Parentheses](#parentheses)
+  1. [Tags](#tags)
+  1. [Methods](#methods)
+  1. [Ordering](#ordering)
+  1. [`isMounted`](#ismounted)
+
+## Basic Rules
+
+  - Always use JSX syntax.
+  - Do not use `React.createElement` unless you're initializing the app from a file that is not JSX.
+  - Prefer stateless components. There are many benefits to this approach including performance optimizations.
+
+## Class vs `React.createClass`
+
+  - Use `class extends React.Component` not `React.createClass`
+
+  eslint rules: [`react/prefer-es6-class`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md).
+
+    ```javascript
+    // bad
+    const Listing = React.createClass({
+      render() {
+        return <div />;
+      }
+    });
+
+    // good
+    class Listing extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
+    ```
+
+## Naming
+
+  - **Extensions**: Use `.jsx` extension for React components.
+  - **Filename**: Use lowercase for filenames. E.g., `reservationcard.jsx`.
+  - **Reference Naming**: Use PascalCase for React components and camelCase for their instances.
+
+  eslint rules: [`react/jsx-pascal-case`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md).
+
+    ```javascript
+    // bad
+    import reservationCard from './ReservationCard';
+
+    // good
+    import ReservationCard from './ReservationCard';
+
+    // bad
+    const ReservationItem = <ReservationCard />;
+
+    // good
+    const reservationItem = <ReservationCard />;
+    ```
+
+  - **Component Naming**: Use the filename as the component name. For example, `ReservationCard.jsx` should have a reference name of `ReservationCard`. However, for root components of a directory, use `index.jsx` as the filename and use the directory name as the component name:
+
+    ```javascript
+    // bad
+    import Footer from './Footer/Footer';
+
+    // bad
+    import Footer from './Footer/index';
+
+    // good
+    import Footer from './Footer';
+    ```
+
+## Declaration
+
+  - Do not use `displayName` for naming components. Instead, name the component by reference.
+
+    ```javascript
+    // bad
+    export default React.createClass({
+      displayName: 'ReservationCard',
+      // stuff goes here
+    });
+
+    // good
+    export default class ReservationCard extends React.Component {
+    }
+    ```
+
+## Alignment
+
+  - Follow these alignment styles for JSX syntax
+
+  eslint rules: [`react/jsx-closing-bracket-location`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md).
+
+    ```javascript
+    // bad
+    <Foo superLongParam='bar'
+         anotherSuperLongParam='baz' />
+
+    // good
+    <Foo
+      superLongParam='bar'
+      anotherSuperLongParam='baz'
+    />
+
+    // if props fit in one line then keep it on the same line
+    <Foo bar="bar" />
+
+    // children get indented normally
+    <Foo
+      superLongParam='bar'
+      anotherSuperLongParam='baz'
+    >
+      <Spazz />
+    </Foo>
+    ```
+
+## Spacing
+
+  - Always include a single space in your self-closing tag.
+
+    ```javascript
+    // bad
+    <Foo/>
+
+    // very bad
+    <Foo                 />
+
+    // bad
+    <Foo
+     />
+
+    // good
+    <Foo />
+    ```
+
+## Props
+
+  - Always use camelCase for prop names.
+
+    ```javascript
+    // bad
+    <Foo
+      UserName='hello'
+      phone_number={ 12345678 }
+    />
+
+    // good
+    <Foo
+      userName='hello'
+      phoneNumber={ 12345678 }
+    />
+    ```
+
+  - Add space inside curly braces. As with normal Javascript Objects.
+
+  ```javascript
+  //bad
+  <Foo
+    foo={bar}
+  />
+
+  //good
+  <Foo
+    foo={ bar }
+  />
+  ```
+
+  - Do not omit the value of the prop when it is explicitly `true`.
+
+  eslint rules: [`react/jsx-boolean-value`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md).
+
+    ```javascript
+    // good
+    <Foo
+      hidden={ true }
+    />
+
+    // bad
+    <Foo
+      hidden
+    />
+    ```
+
+## Parentheses
+
+  - Aways wrap JSX tags in parentheses.
+
+  eslint rules: [`react/wrap-multilines`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md).
+
+    ```javascript
+    // bad
+    render() {
+      return <MyComponent className='long body' foo='bar'>
+               <MyChild />
+             </MyComponent>;
+    }
+
+    // good
+    render() {
+      return (
+        <MyComponent className='long body' foo='bar'>
+          <MyChild />
+        </MyComponent>
+      );
+    }
+
+    ```
+
+## Tags
+
+  - Always self-close tags that have no children.
+
+  eslint rules: [`react/self-closing-comp`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md).
+
+    ```javascript
+    // bad
+    <Foo className='stuff'></Foo>
+
+    // good
+    <Foo className='stuff' />
+    ```
+
+  - If your component has multi-line properties, close its tag on a new line.
+
+  eslint rules: [`react/jsx-closing-bracket-location`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md).
+
+    ```javascript
+    // bad
+    <Foo
+      bar='bar'
+      baz='baz' />
+
+    // good
+    <Foo
+      bar='bar'
+      baz='baz'
+    />
+    ```
+
+## Methods
+
+  - Bind event handlers for the render method in the constructor.
+
+  > Why? A bind call in a the render path creates a brand new function on every single render.
+
+  eslint rules: [`react/jsx-no-bind`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md).
+
+    ```javascript
+    // bad
+    class extends React.Component {
+      onClickDiv() {
+        // do stuff
+      }
+
+      render() {
+        return <div onClick={this.onClickDiv.bind(this)} />
+      }
+    }
+
+    // good
+    class extends React.Component {
+      constructor(props) {
+        super(props);
+
+        this.onClickDiv = this.onClickDiv.bind(this);
+      }
+
+      onClickDiv() {
+        // do stuff
+      }
+
+      render() {
+        return <div onClick={this.onClickDiv} />
+      }
+    }
+    ```
+
+## Ordering
+
+  - Ordering for `class extends React.Component`:
+
+  1. `constructor`
+  1. optional `static` methods
+  1. `getChildContext`
+  1. `componentWillMount`
+  1. `componentDidMount`
+  1. `componentWillReceiveProps`
+  1. `shouldComponentUpdate`
+  1. `componentWillUpdate`
+  1. `componentDidUpdate`
+  1. `componentWillUnmount`
+  1. *clickHandlers or eventHandlers* like `onClickSubmit()` or `onChangeDescription()`
+  1. *getter methods for `render`* like `getSelectReason()` or `getFooterContent()`
+  1. *Optional render methods* like `renderNavigation()` or `renderProfilePicture()`
+  1. `render`
+
+  eslint rules: [`react/sort-comp`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md).
+
+**[⬆ back to top](#table-of-contents)**


### PR DESCRIPTION
The old javascript guide was also moved to /es5

:eyeglasses: @ajacksified @schwers @nramadas @madbook @dwick and whoever else cares

Updated with the latest version of the Airbnb style guide and applied the same handful of changes that we made to the original. I also added their React styleguide and removed a few things we don't do.

Getting a little weary of scanning around this so seems like a good time for input.

Here are some specific parts to look at.

JS
--------
* Arrays
  use slice to copy array too?

* Arrow functions
  what styles do we prefer?

* comments
  fixme /todo convention?

* Naming conventions
  possible rule; name constants with all caps?

React
----------
* ordering (do we even care that much? conventions might be nice though)

